### PR TITLE
I've addressed several Rust compilation errors and warnings in your c…

### DIFF
--- a/src/eigensnp.rs
+++ b/src/eigensnp.rs
@@ -1,7 +1,7 @@
 use ndarray::{s, Array1, Array2, Axis, ArrayView2};
 // Eigh, QR, SVDInto are replaced by backend calls. UPLO is handled by eigh_upper.
 // use ndarray_linalg::{Eigh, UPLO, QR, SVDInto}; 
-use crate::linalg_backends::{BackendEigh, BackendQR, BackendSVD, EighOutput, SVDOutput, LinAlgBackendProvider};
+use crate::linalg_backends::{BackendEigh, BackendQR, BackendSVD, LinAlgBackendProvider};
 // use crate::ndarray_backend::NdarrayLinAlgBackend; // Replaced by LinAlgBackendProvider
 // use crate::linalg_backend_dispatch::LinAlgBackendProvider; // Now part of linalg_backends
 use rayon::prelude::*;
@@ -661,7 +661,7 @@ impl EigenSNPCoreAlgorithm {
         });
         
         let backend = LinAlgBackendProvider::<f32>::new(); // Use LinAlgBackendProvider for f32
-        let mut orthonormal_basis_candidate = matrix_features_by_samples.dot(&random_projection_matrix_samples_by_sketch);
+        let orthonormal_basis_candidate = matrix_features_by_samples.dot(&random_projection_matrix_samples_by_sketch);
 
         if orthonormal_basis_candidate.ncols() == 0 {
             warn!("RSVD: Initial sketch Y (A*Omega) has zero columns before first QR. Target_K={}, Sketch_L={}", num_components_target_k, sketch_dimension);

--- a/src/pca.rs
+++ b/src/pca.rs
@@ -6,7 +6,7 @@ use ndarray::{s, Array1, Array2, Axis, ArrayView1};
 // UPLO is no longer needed as the backend's eigh_upper handles this.
 // QR trait for .qr() and SVDInto for .svd_into() are replaced by backend calls.
 // Eigh trait for .eigh() is replaced by backend calls.
-use crate::linalg_backends::{BackendEigh, BackendQR, BackendSVD, EighOutput, SVDOutput, LinAlgBackendProvider};
+use crate::linalg_backends::{BackendEigh, BackendQR, BackendSVD, LinAlgBackendProvider};
 // use crate::ndarray_backend::NdarrayLinAlgBackend; // Replaced by LinAlgBackendProvider
 // use crate::linalg_backend_dispatch::LinAlgBackendProvider; // Now part of linalg_backends
 use rand::Rng;
@@ -539,7 +539,7 @@ impl PCA {
                 });
 
             // Initial sketch: Y = A @ Omega_prime
-            let mut q_prime_basis_candidate = centered_scaled_data_a.dot(&omega_prime_random_matrix); // (N x D) @ (D x L) -> N x L
+            let q_prime_basis_candidate = centered_scaled_data_a.dot(&omega_prime_random_matrix); // (N x D) @ (D x L) -> N x L
             if q_prime_basis_candidate.ncols() == 0 { // Should only happen if l_sketch_components was 0
                  return Err("Sketch Q'_basis_candidate (from A) has zero columns before QR. This indicates l_sketch_components became 0.".into());
             }
@@ -597,7 +597,7 @@ impl PCA {
                 });
 
             // Initial sketch: Y_aat_candidate = A.T @ Omega
-            let mut q_basis_candidate = centered_scaled_data_a.t().dot(&omega_random_matrix); // (D x N) @ (N x L) -> D x L
+            let q_basis_candidate = centered_scaled_data_a.t().dot(&omega_random_matrix); // (D x N) @ (N x L) -> D x L
             if q_basis_candidate.ncols() == 0 {
                 return Err("Initial sketch Q_basis_candidate (from A.T) has zero columns before QR. This indicates l_sketch_components became 0.".into());
             }


### PR DESCRIPTION


Here's a summary of the changes I made:

- In `src/linalg_backends.rs`, I refactored how `LinAlgBackendProvider` is implemented to resolve an issue with unstable attributes. This should make the conditional compilation of trait bounds work correctly.

- Also in `src/linalg_backends.rs`, I fixed an error related to a missing method (`ok_or_else`) in `NdarrayLinAlgBackend::qr_q_factor`. I've adjusted how the Q factor is handled, assuming it's returned directly.

- I removed some unused imports:
    - `Lapack` and `Scalar` from `ndarray_linalg` in `src/linalg_backends.rs`.
    - `EighOutput` and `SVDOutput` from `crate::linalg_backends` in `src/pca.rs` and `src/eigensnp.rs`.

- I also removed unnecessary `mut` qualifiers from variables that were assigned once but not changed later in `src/pca.rs` and `src/eigensnp.rs`.