### PR TITLE
Refactor(faer): Resolve Faer backend compilation & CI issue creation

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -195,7 +195,7 @@ jobs:
             }
 
       - name: Create failure issue
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/main' || github.event_name == 'pull_request' && github.base_ref == 'main')
         uses: peter-evans/create-issue-from-file@v5
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This commit addresses several compilation errors for the `backend_faer` feature and updates the GitHub Actions workflow for CI failure issue creation.

Faer Backend Fixes:
1.  **`LinAlgBackendProvider` Definition Order:** Moved the `LinAlgBackendProvider` struct definition and its `impl New` block to the top of `src/linalg_backends.rs` to avoid potential compiler confusion with `#[cfg]` attributes.

2.  **`faer` Crate API Usage (v0.22.6):**
    - Updated SVD-related imports in the `faer_specific_code` module to use `faer::linalg::solvers::Svd as FaerSolverSvd` and correct supporting types.
    - Refactored SVD logic to use `FaerSolverSvd::new_thin()` and align extraction of S, U, V^T with the newer API.
    - Removed unused `faer` imports like `Parallelism`, `GlobalPodBuffer`, and `ComputeVectors` from the SVD codepath as they are no longer needed with the `FaerSolverSvd::new_thin()` API.

3.  **`is_fcontiguous` for Memory Layout Check:** Replaced `matrix_view.is_fortran()` with `matrix_view.is_fcontiguous()` in `faer_specific_code`.

4.  **Unsafe Blocks for `get_unchecked`:** Wrapped calls to `get_unchecked` in `unsafe {}` blocks within `faer_specific_code`.

GitHub Actions Workflow:
- Modified the `if` condition for the "Create failure issue" step in the `consolidate-failures` job in `.github/workflows/rust.yml`. Issues will now be created on CI failures for pushes to `main` OR for pull requests targeting `main`.

MKL Backend (`lax` crate issue):
The compilation error E0259 for `backend_mkl` (related to `lax` crate aliases) is not addressed by these code changes. It's recommended to investigate patching `lax` or further refining the build process for MKL if this backend is critical.