### PR TITLE
Fix: Resolve linker errors for faer backend tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ rayon = "1.10.0"
 serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = "0.33.1"
 tempfile = "3.20.0"
+openblas-src = { version = "~0.10", optional = true }
+lapack-src = { version = "~0.11", optional = true }
 
 [lib]
 name = "efficient_pca"
@@ -60,7 +62,8 @@ ndarray_v15 = { version = "0.15.6", package = "ndarray" }
 default = ["backend_openblas"]
 backend_openblas = ["ndarray-linalg/openblas-static"]
 backend_mkl = ["ndarray-linalg/intel-mkl-static"]
-backend_faer = ["dep:faer"]
+backend_faer = ["dep:faer", "faer_openblas_static_linking_feature"]
+faer_openblas_static_linking_feature = ["openblas-src/static", "lapack-src/openblas"]
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
The faer backend tests were failing due to undefined LAPACK symbols (e.g., dsyev_, dgelqf_). This occurred because the faer crate, when enabled via the `backend_faer` feature, was not explicitly configured to link a specific LAPACK provider, likely defaulting to dynamic linking which failed in the CI environment.

This commit addresses the issue by:
1. Adding `openblas-src` and `lapack-src` as optional dependencies to `efficient_pca/Cargo.toml`.
2. Introducing a new feature flag, `faer_openblas_static_linking_feature`, which enables static compilation of OpenBLAS via `openblas-src/static` and configures `lapack-src` to use this OpenBLAS via `lapack-src/openblas`.
3. Modifying the `backend_faer` feature to include the new `faer_openblas_static_linking_feature`.

This ensures that when the `faer` backend is used, a statically linked OpenBLAS library is available, providing the necessary LAPACK symbols and resolving the test failures.