### PR TITLE
Fix: Resolve linker errors for faer backend tests (v2)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -29,7 +29,7 @@ jobs:
             rustflags: "-L/opt/intel/oneapi/mkl/latest/lib/intel64"
           - backend: faer
             feature: backend_faer
-            rustflags: ""
+            rustflags: "--cfg openblas"
 
     steps:
       - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ rayon = "1.10.0"
 serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = "0.33.1"
 tempfile = "3.20.0"
+openblas-src = { version = "~0.10", optional = true }
+lapack-src = { version = "~0.11", optional = true }
 
 [lib]
 name = "efficient_pca"
@@ -60,7 +62,8 @@ ndarray_v15 = { version = "0.15.6", package = "ndarray" }
 default = ["backend_openblas"]
 backend_openblas = ["ndarray-linalg/openblas-static"]
 backend_mkl = ["ndarray-linalg/intel-mkl-static"]
-backend_faer = ["dep:faer"]
+backend_faer = ["dep:faer", "faer_sys_links_openblas"]
+faer_sys_links_openblas = ["openblas-src/static", "lapack-src/openblas"]
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
This commit addresses the persistent linker errors for the `faer` backend, where symbols like `dsyev_` were undefined when linking tests. The issue arose because `faer` (specifically its internal `lax` component) requires not only a LAPACK library to be available but also a `cfg` flag (e.g., `openblas`) to be set during its compilation to correctly interface with the LAPACK provider.

This fix implements a two-pronged approach:

1.  **Modifies `efficient_pca/Cargo.toml`:**
    *   Ensures `openblas-src` (with `static` feature) and `lapack-src`
        (with `openblas` feature) are included as dependencies when the
        `backend_faer` feature is enabled. This makes a statically
        linked OpenBLAS library available.
    *   The feature `faer_sys_links_openblas` is used to group these
        system-level linking dependencies for clarity.

2.  **Modifies `.github/workflows/rust.yml`:**
    *   For the CI job corresponding to the `faer` backend, `RUSTFLAGS`
        is now set to `"--cfg openblas"`. This signals to the `faer`
        crate (and its dependencies) that it should compile itself in a
        mode compatible with an OpenBLAS backend, likely by enabling
        its internal usage of `lapack-sys` bindings.

This approach aligns `efficient_pca`'s usage of `faer` with how `faer` appears to configure itself for backend-specific testing (as suggested by its `dev-dependencies` structure), ensuring that `faer`'s compiled code correctly links against the provided OpenBLAS library.