### PR TITLE
I've fixed an issue where the `faer` backend wasn't linking correctly…

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -50,7 +50,7 @@ jobs:
           pip install numpy scikit-learn scipy
 
       - name: Install OpenBLAS
-        if: matrix.backend == 'openblas'
+        if: matrix.backend == 'openblas' || matrix.backend == 'faer'
         run: |
           sudo apt-get update -qq
           sudo apt-get install -y libopenblas-dev

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,7 +63,7 @@ default = ["backend_openblas"]
 backend_openblas = ["ndarray-linalg/openblas-static"]
 backend_mkl = ["ndarray-linalg/intel-mkl-static"]
 backend_faer = ["dep:faer", "faer_sys_links_openblas"]
-faer_sys_links_openblas = ["openblas-src/static", "lapack-src/openblas"]
+faer_sys_links_openblas = ["openblas-src/system", "lapack-src/openblas"]
 
 [[bench]]
 name = "benchmarks"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -8,7 +8,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::time::Instant; // Keep for benchmark_pca internal timing, though Criterion handles overall.
-use sysinfo::System; // Added SystemExt, ProcessExt, PidExt for sysinfo
+use sysinfo::{System, Process, Pid}; // Added SystemExt, ProcessExt, PidExt for sysinfo
 
 // Enum to specify the type of data source for benchmarks.
 #[derive(Clone, Debug)] // Added Clone and Debug for DataSource


### PR DESCRIPTION
… with a LAPACK-enabled OpenBLAS.

Previously, you were seeing persistent linker errors for the `faer` backend tests. This was because symbols like `dsyev_` and `dgeqrf_` were undefined.

It seems the problem was that `openblas-src`, when building OpenBLAS from source, was likely compiling it without LAPACK support. This happened because a Fortran compiler wasn't available in the CI environment for the `faer` job. As a result, the OpenBLAS library only contained BLAS symbols.

Here’s how I've addressed this:

1.  **I modified `efficient_pca/Cargo.toml` for `backend_faer`:**
    *   I changed the feature `faer_sys_links_openblas` (or its equivalent) to use `openblas-src = { features = ["system"] }` instead of `["static"]`. This tells `openblas-src` to link against a system-provided OpenBLAS library.
    *   I kept `lapack-src = { features = ["openblas"] }` to ensure `lapack-src` uses the OpenBLAS bindings.

2.  **I modified the `.github/workflows/rust.yml` CI configuration:**
    *   The CI step that installs `libopenblas-dev` (which includes LAPACK on Ubuntu) is now also executed for the `faer` backend CI job. This ensures a LAPACK-enabled OpenBLAS is available on the system.
    *   I maintained `RUSTFLAGS="--cfg openblas"` for the `faer` backend job. This flag instructs the `faer` crate to compile itself in a mode that correctly utilizes the (now system-provided) OpenBLAS + LAPACK backend, likely via `lapack-sys`.

This approach ensures that a complete OpenBLAS+LAPACK library is available and that `faer` is configured to use it, which should resolve the linker errors you were experiencing.