### PR TITLE
Fix: Ensure faer backend links LAPACK via static ndarray-linalg/openblas

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -27,9 +27,9 @@ jobs:
           - backend: mkl
             feature: backend_mkl
             rustflags: "-L/opt/intel/oneapi/mkl/latest/lib/intel64"
-          - backend: faer
-            feature: backend_faer
-            rustflags: "--cfg openblas"
+          - backend: faer # This name is just a label for the matrix row
+            feature: "faer_links_ndarray_static_openblas"
+            rustflags: ""
 
     steps:
       - uses: actions/checkout@v4
@@ -49,11 +49,10 @@ jobs:
           python -m pip install --upgrade pip
           pip install numpy scikit-learn scipy
 
-      - name: Install OpenBLAS
+      - name: Install Fortran compiler
         if: matrix.backend == 'openblas' || matrix.backend == 'faer'
         run: |
-          sudo apt-get update -qq
-          sudo apt-get install -y libopenblas-dev
+          sudo apt-get update -qq && sudo apt-get install -y gfortran
 
       - name: Install Intel MKL
         if: matrix.backend == 'mkl'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,8 +40,6 @@ rayon = "1.10.0"
 serde = { version = "1.0.219", features = ["derive"] }
 sysinfo = "0.33.1"
 tempfile = "3.20.0"
-openblas-src = { version = "~0.10", optional = true }
-lapack-src = { version = "~0.11", optional = true }
 
 [lib]
 name = "efficient_pca"
@@ -62,8 +60,10 @@ ndarray_v15 = { version = "0.15.6", package = "ndarray" }
 default = ["backend_openblas"]
 backend_openblas = ["ndarray-linalg/openblas-static"]
 backend_mkl = ["ndarray-linalg/intel-mkl-static"]
-backend_faer = ["dep:faer", "faer_sys_links_openblas"]
-faer_sys_links_openblas = ["openblas-src/system", "lapack-src/openblas"]
+faer_links_ndarray_static_openblas = [
+    "dep:faer",
+    "ndarray-linalg/openblas-static"
+]
 
 [[bench]]
 name = "benchmarks"


### PR DESCRIPTION
This commit resolves linker errors for the CI job involving the `faer` backend, where LAPACK symbols (e.g., `dsyev_`) were undefined. The errors stemmed from `ndarray-linalg` (and its `lax` component) expecting a LAPACK-enabled OpenBLAS library but not being correctly configured by the `efficient_pca` crate for the `faer` backend scenario.

This solution implements the robust static build strategy:

1.  **Modified `efficient_pca/Cargo.toml`:**
    *   A new composite feature, `faer_links_ndarray_static_openblas`,
        is defined. It enables:
        *   `dep:faer` (to include `faer` itself).
        *   `ndarray-linalg/openblas-static` (this feature correctly
            configures `ndarray-linalg` to build OpenBLAS from source
            statically, including LAPACK, and manage its transitive
            dependencies like `openblas-src` and `lapack-src`).
    *   Direct optional dependencies on `openblas-src` and `lapack-src`
        were removed from `efficient_pca`, as they are now solely
        managed by `ndarray-linalg`.
    *   Previous `faer`-related backend features and `cfg` flags that
        were causing issues or were redundant have been removed or corrected.

2.  **Modified `.github/workflows/rust.yml`:**
    *   The CI matrix entry for the `faer` backend now enables the new
        `faer_links_ndarray_static_openblas` feature.
    *   `RUSTFLAGS` for this CI entry is cleared (the `--cfg openblas`
        hack is removed as `ndarray-linalg/openblas-static` handles
        configuration).
    *   The system package installation step for the `faer` (and `openblas`)
        backend jobs is updated to "Install Fortran compiler" and now
        installs only `gfortran`. This is necessary for `openblas-src`
        (a transitive dependency of `ndarray-linalg/openblas-static`)
        to compile OpenBLAS and its LAPACK components from source.
        `libopenblas-dev` is no longer installed by this step as the
        OpenBLAS library will be built from source.

This approach ensures that `ndarray-linalg` correctly builds and links a static, LAPACK-enabled OpenBLAS library, resolving the undefined symbol errors in a robust and Cargo-idiomatic way.