### PR TITLE
Fix(cargo): Resolve unexpected_cfgs warnings for backend_faer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,7 @@ ndarray_v15 = { version = "0.15.6", package = "ndarray" }
 default = ["backend_openblas"]
 backend_openblas = ["ndarray-linalg/openblas-static"]
 backend_mkl = ["ndarray-linalg/intel-mkl-static"]
+backend_faer = ["faer_links_ndarray_static_openblas"]
 faer_links_ndarray_static_openblas = [
     "dep:faer",
     "ndarray-linalg/openblas-static"

--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -8,7 +8,7 @@ use std::fs::OpenOptions;
 use std::io::Write;
 use std::path::Path;
 use std::time::Instant; // Keep for benchmark_pca internal timing, though Criterion handles overall.
-use sysinfo::{System, Process, Pid}; // Added SystemExt, ProcessExt, PidExt for sysinfo
+use sysinfo::System; // Added SystemExt, ProcessExt, PidExt for sysinfo
 
 // Enum to specify the type of data source for benchmarks.
 #[derive(Clone, Debug)] // Added Clone and Debug for DataSource


### PR DESCRIPTION
Defines `backend_faer` as a known feature in `Cargo.toml` by aliasing it to `faer_links_ndarray_static_openblas`. This prevents the Rust compiler from issuing warnings about an unknown cfg condition when `#[cfg(feature = "backend_faer")]` is used.

Additionally, this commit removes unused imports (`Process`, `Pid`) from `benches/benchmarks.rs` to resolve an `unused_imports` warning.