### PR TITLE
Fix: Correct benchmark artifact download and improve plot aesthetics

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -232,7 +232,7 @@ jobs:
         with:
           # Pattern to download all raw benchmark TSVs from different backends
           pattern: raw-benchmark-results-*.tsv 
-          path: benches/benchmark_artifacts/ # this matches script's input dir
+          path: benches/benchmark_artifacts # Changed this line
           # 'merge-multiple' is true by default if 'name' is not given and 'pattern' is.
           # This should place all downloaded files into the 'path' directory.
 

--- a/benches/analyze_benchmarks.py
+++ b/benches/analyze_benchmarks.py
@@ -129,6 +129,8 @@ def generate_plots(df_raw):
     if not os.path.exists(OUTPUT_DIR):
         os.makedirs(OUTPUT_DIR)
 
+    sns.set_theme(style="whitegrid", palette="pastel") # Global Seaborn style
+
     for scenario in KEY_SCENARIOS_FOR_PLOTS_STATS:
         for run_type in ["fit", "rfit"]:
             scenario_df = df_raw[(df_raw['ScenarioName'] == scenario) & (df_raw['RunType'] == run_type)]
@@ -139,12 +141,15 @@ def generate_plots(df_raw):
             # TimeSec plot
             plt.figure(figsize=(10, 6))
             sns.boxplot(x='BackendName', y='TimeSec', data=scenario_df)
-            plt.title(f'Time Comparison for {scenario} - {run_type}')
-            plt.ylabel('Time (seconds)')
-            plt.xlabel('Backend')
+            plt.title(f'Execution Time: {scenario} - {run_type}', fontsize=16)
+            plt.ylabel('Time (seconds)', fontsize=12)
+            plt.xlabel('Backend', fontsize=12)
+            plt.xticks(fontsize=10)
+            plt.yticks(fontsize=10)
+            plt.tight_layout()
             plot_filename_time = os.path.join(OUTPUT_DIR, f'plot_time_{scenario}_{run_type}.png')
             try:
-                plt.savefig(plot_filename_time)
+                plt.savefig(plot_filename_time, dpi=150)
                 print(f"Saved plot: {plot_filename_time}")
             except Exception as e:
                 print(f"Error saving plot {plot_filename_time}: {e}")
@@ -153,12 +158,15 @@ def generate_plots(df_raw):
             # RSSDeltaKB plot
             plt.figure(figsize=(10, 6))
             sns.boxplot(x='BackendName', y='RSSDeltaKB', data=scenario_df)
-            plt.title(f'RSS Memory Comparison for {scenario} - {run_type}')
-            plt.ylabel('RSS Delta (KB)')
-            plt.xlabel('Backend')
+            plt.title(f'RSS Memory Usage: {scenario} - {run_type}', fontsize=16)
+            plt.ylabel('RSS Delta (KB)', fontsize=12)
+            plt.xlabel('Backend', fontsize=12)
+            plt.xticks(fontsize=10)
+            plt.yticks(fontsize=10)
+            plt.tight_layout()
             plot_filename_rss = os.path.join(OUTPUT_DIR, f'plot_rss_{scenario}_{run_type}.png')
             try:
-                plt.savefig(plot_filename_rss)
+                plt.savefig(plot_filename_rss, dpi=150)
                 print(f"Saved plot: {plot_filename_rss}")
             except Exception as e:
                 print(f"Error saving plot {plot_filename_rss}: {e}")


### PR DESCRIPTION
This commit addresses two main issues:

1.  **Benchmark Artifact Download:** I modified the `.github/workflows/rust.yml` file to change the `path` parameter in the `actions/download-artifact@v4` step from `benches/benchmark_artifacts/` to `benches/benchmark_artifacts` (i.e. removed trailing slash). This aims to resolve an issue where downloaded benchmark result files were being misinterpreted as directories by the analysis script. The configuration now aligns with the expectation that artifacts are downloaded directly into the specified path.

2.  **Plot Aesthetics and Readability:** I enhanced the `generate_plots` function in `benches/analyze_benchmarks.py`:
    - I set a global Seaborn theme (`style="whitegrid", palette="pastel"`) for better visual appeal.
    - I increased the DPI of saved plot images to 150 for better clarity.
    - I made plot titles more descriptive and increased their font size.
    - I increased font sizes for axis labels and tick labels.
    - I added `plt.tight_layout()` to ensure plot elements are well-arranged and prevent overlaps.