### PR TITLE
Refactor PCA calculation for mathematical correctness and performance.

### DIFF
--- a/tests/eigensnp_tests.rs
+++ b/tests/eigensnp_tests.rs
@@ -1,1 +1,99 @@
+// In tests/eigensnp_tests.rs
 
+use efficient_pca::eigensnp::{reorder_array_owned, reorder_columns_owned};
+
+use ndarray::{Array1, Array2, arr2};
+
+#[test]
+fn test_reorder_array_basic() {
+    let original = Array1::from(vec![10, 20, 30, 40]);
+    let order = vec![2, 0, 3, 1];
+    let expected = Array1::from(vec![30, 10, 40, 20]);
+    let reordered = reorder_array_owned(&original, &order);
+    assert_eq!(reordered, expected);
+}
+
+#[test]
+fn test_reorder_array_empty_array_empty_order() {
+    let original = Array1::<i32>::from(vec![]);
+    let order_empty = vec![];
+    let expected = Array1::<i32>::from(vec![]);
+    let reordered_empty_order = reorder_array_owned(&original, &order_empty);
+    assert_eq!(reordered_empty_order, expected);
+}
+
+#[test]
+#[should_panic]
+fn test_reorder_array_select_from_zero_elements_panics() {
+    let original = Array1::<i32>::from(vec![]);
+    let order = vec![0];
+    reorder_array_owned(&original, &order);
+}
+
+#[test]
+fn test_reorder_array_empty_order() {
+    let original = Array1::from(vec![10, 20, 30]);
+    let order = vec![];
+    let expected = Array1::<i32>::from(vec![]);
+    let reordered = reorder_array_owned(&original, &order);
+    assert_eq!(reordered, expected);
+}
+
+#[test]
+fn test_reorder_array_repeated_indices() {
+    let original = Array1::from(vec![10, 20, 30]);
+    let order = vec![0, 1, 0, 2, 1, 1];
+    let expected = Array1::from(vec![10, 20, 10, 30, 20, 20]);
+    let reordered = reorder_array_owned(&original, &order);
+    assert_eq!(reordered, expected);
+}
+
+#[test]
+fn test_reorder_columns_basic() {
+    let original = arr2(&[[1, 2, 3], [4, 5, 6]]);
+    let order = vec![2, 0, 1];
+    let expected = arr2(&[[3, 1, 2], [6, 4, 5]]);
+    let reordered = reorder_columns_owned(&original, &order);
+    assert_eq!(reordered, expected);
+}
+
+#[test]
+fn test_reorder_columns_empty_matrix_variants() {
+    let original_0_rows = Array2::<i32>::zeros((0, 3));
+    let order = vec![1, 0, 2];
+    let expected_0_rows = Array2::<i32>::zeros((0, 3));
+    let reordered_0_rows = reorder_columns_owned(&original_0_rows, &order);
+    assert_eq!(reordered_0_rows, expected_0_rows);
+
+    let original_0_cols = Array2::<i32>::zeros((2, 0));
+    let order_empty = vec![];
+    let expected_0_cols_empty_order = Array2::<i32>::zeros((2,0));
+    let reordered_empty_order = reorder_columns_owned(&original_0_cols, &order_empty);
+    assert_eq!(reordered_empty_order, expected_0_cols_empty_order);
+}
+
+#[test]
+#[should_panic]
+fn test_reorder_columns_select_from_zero_cols_panics() {
+    let original_0_cols = Array2::<i32>::zeros((2, 0));
+    let order_for_0_cols = vec![0];
+    reorder_columns_owned(&original_0_cols, &order_for_0_cols);
+}
+   
+#[test]
+fn test_reorder_columns_empty_order() {
+    let original = arr2(&[[1, 2, 3], [4, 5, 6]]);
+    let order = vec![];
+    let expected = Array2::<i32>::zeros((2, 0));
+    let reordered = reorder_columns_owned(&original, &order);
+    assert_eq!(reordered, expected);
+}
+
+#[test]
+fn test_reorder_columns_repeated_indices() {
+    let original = arr2(&[[1, 2], [3, 4]]);
+    let order = vec![0, 1, 0, 0];
+    let expected = arr2(&[[1, 2, 1, 1], [3, 4, 3, 3]]);
+    let reordered = reorder_columns_owned(&original, &order);
+    assert_eq!(reordered, expected);
+}


### PR DESCRIPTION
This commit implements several critical fixes and improvements based on external critiques:

1.  **PCA Mathematical Correctness:**
    *   The final refinement stage now uses an SVD on intermediate scores (X^T * V_qr) to ensure true principal components are computed.
    *   Final SNP PC loadings are now V_final = V_qr * V_rot.
    *   Final sample PC scores are now S_final = U_rot * Sigma_rot.
    *   Eigenvalues are correctly derived from the singular values of this new SVD: lambda_k = (s'_k)^2 / (N-1).

2.  **Sorting of Outputs:**
    *   Final SNP loadings, sample scores, and eigenvalues are now sorted in descending order of eigenvalues.
    *   Helper functions `reorder_columns_owned` and `reorder_array_owned` are used for this.

3.  **Performance and Precision:**
    *   The parallel summation for intermediate score calculation now uses a `fold().reduce()` pattern with `f64` accumulation. This improves precision for the intermediate scores matrix and reduces unnecessary allocations from the previous `reduce(|| Array2::zeros(...))` pattern.

4.  **Configuration Default:**
    *   The default for `local_rsvd_num_power_iterations` in `EigenSNPCoreAlgorithmConfig` has been changed from 1 to 2 for improved robustness in local basis learning.

5.  **Integration and Testing:**
    *   The main `compute_pca` flow was updated to integrate these changes.
    *   The function `compute_final_scores_and_eigenvalues` was renamed to `compute_rotated_final_outputs` to better reflect its new role.
    *   Unit tests were added for the sorting helper functions.

These changes address the core mathematical inaccuracies in the previous PCA implementation, improve numerical precision in key calculations, optimize a performance bottleneck, and align a configuration default with best practices.