### PR TITLE
Fix: Correct usage of into_shape_with_order in tests

### DIFF
--- a/tests/eigensnp_tests.rs
+++ b/tests/eigensnp_tests.rs
@@ -256,7 +256,7 @@ mod eigensnp_integration_tests {
                 let eig_array2 = parse_section::<f64>(&mut lines, Some(1))?;
                 // Convert N_eig x 1 Array2 to Array1 of length N_eig
             let eig_len = eig_array2.len(); // Store length before move
-            py_eigenvalues = Some(eig_array2.into_shape_with_order((eig_len,), ndarray::Order::C).expect("Failed to reshape py_eigenvalues"));
+            py_eigenvalues = Some(eig_array2.into_shape_with_order((eig_len,)).expect("Failed to reshape py_eigenvalues"));
             }
         }
         


### PR DESCRIPTION
This commit ensures the correct usage of `into_shape_with_order` in `tests/eigensnp_tests.rs`, resolving an E0061 error where an extra argument was being passed. The method should only take the shape tuple.

This commit also consolidates all previous fixes, including:
- Resolution of E0502 borrow errors in tests.
- Handling of deprecated `into_shape` (by moving to `into_shape_with_order`).
- Making `ThreadSafeStdError` public in `src/eigensnp.rs`.
- Fixing various unused variable and import warnings.
- Core numerical precision improvements in `src/eigensnp.rs`:
    - Correct PC score scaling.
    - f64 accumulation for S_int strip sums.
    - Custom mixed-precision dot product for L_raw strips.
    - Documentation updates for precision considerations.

The codebase should now compile cleanly for both the library and tests.