### PR TITLE
Fix: Correct pca.py output format and unused variable in eigensnp_tests

### DIFF
--- a/tests/eigensnp_tests.rs
+++ b/tests/eigensnp_tests.rs
@@ -119,7 +119,7 @@ mod eigensnp_integration_tests {
 
     impl TestDataAccessor {
         pub fn new(standardized_data: Array2<f32>) -> Self {
-            let num_samples = standardized_data.ncols();
+            // The line `let num_samples = standardized_data.ncols();` has been removed.
             Self {
                 standardized_data,
             }

--- a/tests/pca.py
+++ b/tests/pca.py
@@ -29,7 +29,9 @@ def print_numpy_array_for_rust(arr):
         return
 
     if arr.ndim == 1:
-        print(" ".join(map(str, arr)))
+        # Print each element of the 1D array on a new line
+        for element in arr:
+            print(str(element))
     else: # 2D
         for row in arr:
             print(" ".join(map(str, row)))


### PR DESCRIPTION
- Modified tests/pca.py to print 1D arrays (specifically eigenvalues) with one element per line. This aligns with the parsing expectations in eigensnp_tests.rs, resolving panics in your tests like test_pca_with_known_small_dataset and test_pca_more_components_requested_than_rank.

- Removed an unused `num_samples` variable declaration in the `TestDataAccessor::new` function in tests/eigensnp_tests.rs to eliminate a compiler warning.