### PR TITLE
I've added diagnostics for pca.py output parsing.

### DIFF
--- a/tests/eigensnp_tests.rs
+++ b/tests/eigensnp_tests.rs
@@ -307,8 +307,22 @@ mod eigensnp_integration_tests {
                 String::from_utf8_lossy(&output.stderr));
         }
         let python_output_str = String::from_utf8_lossy(&output.stdout);
+        let stderr_str = String::from_utf8_lossy(&output.stderr); // Capture stderr as string
         let (py_loadings_k_x_d, py_scores_n_x_k, py_eigenvalues_k) = 
-            parse_pca_py_output(&python_output_str).expect("Failed to parse pca.py output");
+            parse_pca_py_output(&python_output_str).expect(
+                &format!(
+                    "Failed to parse pca.py output. Full stdout:
+---
+{}
+---
+Full stderr:
+---
+{}
+---",
+                    python_output_str,
+                    stderr_str
+                )
+            );
 
         let py_loadings_d_x_k = py_loadings_k_x_d.t().into_owned();
 
@@ -613,8 +627,22 @@ mod eigensnp_integration_tests {
                 String::from_utf8_lossy(&py_cmd_output.stderr));
         }
         let python_output_str = String::from_utf8_lossy(&py_cmd_output.stdout);
+        let stderr_str = String::from_utf8_lossy(&py_cmd_output.stderr); // Capture stderr
         let (py_loadings_k_x_d, py_scores_n_x_k, py_eigenvalues_k) = 
-            parse_pca_py_output(&python_output_str).expect("Failed to parse pca.py output for low-rank data");
+            parse_pca_py_output(&python_output_str).expect(
+                &format!(
+                    "Failed to parse pca.py output for low-rank data. Full stdout:
+---
+{}
+---
+Full stderr:
+---
+{}
+---",
+                    python_output_str,
+                    stderr_str
+                )
+            );
         
         let py_loadings_d_x_k = py_loadings_k_x_d.t().into_owned();
 

--- a/tests/pca.py
+++ b/tests/pca.py
@@ -68,6 +68,7 @@ def run_reference_pca_mode(n_components_val): # Renamed from run_rust_test_mode
             print_numpy_array_for_rust(np.array([]).reshape(num_samples_n_fallback, 0))
             print("EIGENVALUES:")
             print_numpy_array_for_rust(np.array([]))
+            print("DEBUG: PCA_PY Exiting early - data_snps_by_samples.size is 0", file=sys.stderr)
             return
 
         num_snps_d = data_snps_by_samples.shape[0]
@@ -81,6 +82,7 @@ def run_reference_pca_mode(n_components_val): # Renamed from run_rust_test_mode
             print_numpy_array_for_rust(np.array([]).reshape(num_samples_n, k_eff))
             print("EIGENVALUES:")
             print_numpy_array_for_rust(np.array([]))
+            print("DEBUG: PCA_PY Exiting early - num_snps_d or num_samples_n is 0", file=sys.stderr)
             return
 
         data_samples_by_snps = data_snps_by_samples.T
@@ -96,19 +98,25 @@ def run_reference_pca_mode(n_components_val): # Renamed from run_rust_test_mode
             print_numpy_array_for_rust(np.array([]).reshape(num_samples_n, 0))
             print("EIGENVALUES:")
             print_numpy_array_for_rust(np.array([]))
+            print("DEBUG: PCA_PY Exiting early - effective_n_components <= 0", file=sys.stderr)
             return
 
         pca = PCA(n_components=effective_n_components, svd_solver='full')
         scores = pca.fit_transform(data_standardized)
         loadings = pca.components_
         eigenvalues = pca.explained_variance_
+        print(f"DEBUG: PCA_PY Computed shapes: Loadings {loadings.shape}, Scores {scores.shape}, Eigenvalues {eigenvalues.shape}", file=sys.stderr)
 
+        print("DEBUG: PCA_PY Pre-Loadings", file=sys.stderr)
         print("LOADINGS:")
         print_numpy_array_for_rust(loadings)
+        print("DEBUG: PCA_PY Post-Loadings, Pre-Scores", file=sys.stderr)
         print("SCORES:")
         print_numpy_array_for_rust(scores)
+        print("DEBUG: PCA_PY Post-Scores, Pre-Eigenvalues", file=sys.stderr)
         print("EIGENVALUES:")
         print_numpy_array_for_rust(eigenvalues)
+        print("DEBUG: PCA_PY Post-Eigenvalues", file=sys.stderr)
 
     except ValueError as e:
         print(f"Error in run_reference_pca_mode: {e}", file=sys.stderr)


### PR DESCRIPTION
- I added extensive debug prints to stderr in tests/pca.py to trace execution flow and data shapes during PCA computation.
- I also enhanced error messages in tests/eigensnp_tests.rs to include the full stdout and stderr from pca.py if parsing its output fails.

These changes are intended to help diagnose why the Rust tests are failing to find the "SCORES:" section in the Python script's output.