### PR TITLE
Fix: Resolve compilation errors in eigensnp_tests.rs

### DIFF
--- a/tests/eigensnp_tests.rs
+++ b/tests/eigensnp_tests.rs
@@ -22,6 +22,7 @@ use std::io::Write; // Removed BufReader, BufRead
 use std::str::FromStr;
 use std::path::PathBuf;
 use std::fs::{self, File}; // Add fs for create_dir_all
+use std::fmt::Write as FmtWrite; // Import with an alias to avoid conflict with std::io::Write
 // use std::io::Write; // Already present
 use std::path::Path; // Add Path
 // use ndarray::{ArrayView1, ArrayView2}; // These are brought in by `use ndarray::{arr2, s, Array1, Array2, ArrayView1, Axis};`
@@ -165,10 +166,8 @@ fn save_vector_to_tsv<T: Display>(
 
 #[cfg(test)]
 mod eigensnp_integration_tests {
-    use crate::eigensnp_integration_tests::generate_structured_data;
     use crate::eigensnp_integration_tests::orthonormalize_columns;
     use super::*; 
-    use std::fmt::Write as FmtWrite; // Import with an alias to avoid conflict with std::io::Write
 
     // Define TestResultRecord struct
     #[derive(Clone, Debug)] // Added Debug


### PR DESCRIPTION
This commit addresses several compilation errors in `tests/eigensnp_tests.rs`:

1.  **E0255 (Duplicate Definition):** I removed the redundant import `use crate::eigensnp_integration_tests::generate_structured_data;`. The function `generate_structured_data` is already defined within the `eigensnp_integration_tests` module, making the import unnecessary.

2.  **E0599 (Method `write_fmt` not found for `&mut String`):** I moved the import `use std::fmt::Write as FmtWrite;` from within the `eigensnp_integration_tests` module to the top-level imports of the file. This makes the `std::fmt::Write` trait (aliased as `FmtWrite`) available globally within the file, allowing the `write!` macro to correctly operate on `String` instances in functions defined outside the `eigensnp_integration_tests` module. This also resolved an unused import warning for `FmtWrite` within that module.

These changes allow the test file to compile successfully.