### PR TITLE
Fix: Capture all eigensnp test artifacts in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -146,8 +146,8 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: eigensnp-test-results-${{ matrix.backend }}
-          path: target/test_artifacts/eigensnp_summary_results.tsv
+          name: eigensnp-test-artifacts-${{ matrix.backend }}
+          path: target/test_artifacts/
           retention-days: 7 # Optional: Keep for 7 days
 
       - name: Benchmark


### PR DESCRIPTION
The GitHub Actions workflow has been updated to upload the entire `target/test_artifacts/` directory for eigensnp tests. Previously, only the `eigensnp_summary_results.tsv` file was captured.

This change ensures that all TSV files generated by individual eigensnp tests (such as loadings, scores, eigenvalues from specific test scenarios) are included in the CI artifacts.

The artifact name has also been updated from
`eigensnp-test-results-${{ matrix.backend }}` to
`eigensnp-test-artifacts-${{ matrix.backend }}` to reflect this broader scope.