### PR TITLE
Fix compilation errors in eigensnp_tests.rs

### DIFF
--- a/src/eigensnp.rs
+++ b/src/eigensnp.rs
@@ -145,7 +145,7 @@ impl InitialSamplePcScores {
 // --- Final Output Structure ---
 
 /// Encapsulates the final results of the EigenSNP PCA computation.
-#[derive(Debug)]
+#[derive(Debug, Default)]
 pub struct EigenSNPCoreOutput {
     /// Final SNP Principal Component Loadings (V_final_star).
     /// Shape: `(num_pca_snps, num_principal_components_computed)`

--- a/tests/eigensnp_tests.rs
+++ b/tests/eigensnp_tests.rs
@@ -2294,9 +2294,6 @@ where
                 num_pca_snps_used: standardized_structured_data.nrows(),
                 num_qc_samples_used: standardized_structured_data.ncols(),
             }
-
-            // Return a dummy output to allow logging to proceed if one run fails
-            EigenSNPCoreOutput::default()
         }
     };
     
@@ -2321,8 +2318,6 @@ where
                 num_pca_snps_used: standardized_structured_data.nrows(),
                 num_qc_samples_used: standardized_structured_data.ncols(),
             }
-
-            EigenSNPCoreOutput::default()
         }
     };
 


### PR DESCRIPTION
- Added `#[derive(Default)]` to `EigenSNPCoreOutput` in `src/eigensnp.rs`.
- Removed redundant `EigenSNPCoreOutput::default()` calls in `run_refinement_improvement_test` within `tests/eigensnp_tests.rs`.

These changes address the `E0599` (no default method) and `expected ';'` errors that were causing the build to fail.