### PR TITLE
Fix: Use ctor for reliable test summary generation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ reqwest = { version = "0.12.15", features = ["blocking"] }
 tar = "0.4.44"
 zstd = "0.13.3"
 criterion = { version = "0.6.0", features = ["html_reports"] }
+ctor = "0.2"
 approx = "0.5.1"
 linfa = "0.7.1"
 linfa-reduction = "0.7.1"


### PR DESCRIPTION
Replaces the previous test-based finalizer (`finalize_and_write_results`) with a destructor function (`#[dtor]`) using the `ctor` crate. This ensures that `eigensnp_summary_results.tsv` is generated reliably after all tests in the `eigensnp_tests` binary have completed, regardless of their execution order or individual pass/fail status.

The `finalize_and_write_results` test was prone to race conditions where it could run before all other tests had populated the global `TEST_RESULTS` vector, leading to an empty or incomplete summary file. The `#[dtor]` approach hooks into the test binary's shutdown process, providing a robust mechanism for this end-of-suite task.

Changes include:
- Added `ctor = "0.2"` to `[dev-dependencies]` in `Cargo.toml`.
- Removed `#[test] fn finalize_and_write_results()` from `tests/eigensnp_tests.rs`.
- Adapted the existing `write_results_to_tsv()` into a private `write_summary_file_impl()` function with added tracing.
- Implemented `#[dtor] fn final_summary_writer()` in `tests/eigensnp_tests.rs` to call `write_summary_file_impl()`.

Note: I was not able to fully verify this change locally by running `cargo test` and the downstream Python analysis script due to an internal issue. The changes were verified through code review.