### PR TITLE
feat: Optimize CI trigger and improve build caching

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened]
 
 env:
   CARGO_TERM_COLOR: always
@@ -107,19 +108,26 @@ jobs:
           echo "MKL_ROOT=/opt/intel/oneapi/mkl/latest" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=/opt/intel/oneapi/mkl/latest/lib/intel64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
 
-      - name: Cache Cargo registry, git, and target directories
+      - name: Cache Cargo global directories (registry, git DBs)
         uses: actions/cache@v4
-        id: cache-cargo
+        id: cache-cargo-global
         with:
           path: |
             ~/.cargo/registry
             ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ matrix.backend }}-${{ hashFiles('**/Cargo.toml') }}
+          key: ${{ runner.os }}-cargo-global-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            ${{ runner.os }}-cargo-${{ matrix.backend }}-${{ hashFiles('**/Cargo.toml') }}-
-            ${{ runner.os }}-cargo-${{ matrix.backend }}-
-            ${{ runner.os }}-cargo-
+            ${{ runner.os }}-cargo-global-
+
+      - name: Cache Cargo build artifacts (target directory)
+        uses: actions/cache@v4
+        id: cache-cargo-target
+        with:
+          path: target
+          key: ${{ runner.os }}-cargo-target-${{ matrix.backend }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}-${{ hashFiles('src/**/*.rs', 'tests/**/*.rs', 'benches/**/*.rs') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-target-${{ matrix.backend }}-${{ hashFiles('**/Cargo.toml', '**/Cargo.lock') }}-
+            ${{ runner.os }}-cargo-target-${{ matrix.backend }}-
 
       - name: Build
         id: build_step


### PR DESCRIPTION
- Modify GitHub Actions workflow to prevent CI runs on pull request merges. The workflow will now only trigger for `opened`, `synchronize`, or `reopened` pull request events.
- Enhance build caching strategy:
  - Separate cache for global Cargo directories (registry, git DBs), keyed by `Cargo.lock`.
  - More granular cache for the `target` directory (build artifacts), keyed by `Cargo.toml`, `Cargo.lock`, and hashes of all `.rs` files in `src`, `tests`, and `benches` directories. This should improve CI performance by better leveraging cached artifacts when only specific parts of the codebase change.