### PR TITLE
Fix: Update ctor, fix imports and resolve compilation errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ reqwest = { version = "0.12.15", features = ["blocking"] }
 tar = "0.4.44"
 zstd = "0.13.3"
 criterion = { version = "0.6.0", features = ["html_reports"] }
+ctor = "0.4.2"
 approx = "0.5.1"
 linfa = "0.7.1"
 linfa-reduction = "0.7.1"


### PR DESCRIPTION
This commit addresses compilation errors and warnings that arose from previous changes to test result summarization.

Specific changes:
- Updated the `ctor` crate version from `0.2.9` to `0.4.2` in `Cargo.toml` as per your instruction.
- Corrected import for `EigenSNPCoreOutput` in `tests/eigensnp_tests.rs` by adding it to the main `efficient_pca::eigensnp` use statement, resolving E0412 and E0422 scope errors.
- Cleaned up unused import warnings in `tests/eigensnp_tests.rs`:
    - Removed redundant top-level imports for `std::fs::OpenOptions`, `std::sync::Mutex`, and `ctor::dtor`.
    - Ensured necessary imports (`OpenOptions`, `File`, `Mutex`, `Path`, `Write`, `dtor`) are correctly scoped and used within the `eigensnp_integration_tests` module for the summary writing logic.

These changes should resolve the CI failures related to compilation errors and ensure the test summary generation using `ctor` works as intended.