### PR TITLE
Fix: Handle missing ErrorMessage column in analyze_eigensnp_results.py

### DIFF
--- a/tests/analyze_eigensnp_results.py
+++ b/tests/analyze_eigensnp_results.py
@@ -166,7 +166,10 @@ def main():
         failed_tests_df = consolidated_summary_df[consolidated_summary_df['Success'].astype(str).str.lower() != 'true']
         if not failed_tests_df.empty:
             md_file.write("## Failed Tests\n\n")
-            md_file.write(failed_tests_df[['TestName', 'backend', 'Success', 'NumPCsComputed', 'ErrorMessage']].to_markdown(index=False) + "\n\n")
+            columns_to_display = ['TestName', 'backend', 'Success', 'NumPCsComputed']
+            if 'ErrorMessage' in failed_tests_df.columns:
+                columns_to_display.append('ErrorMessage')
+            md_file.write(failed_tests_df[columns_to_display].to_markdown(index=False) + "\n\n")
         else:
             md_file.write("## Failed Tests\n\nNo failed tests detected.\n\n")
 


### PR DESCRIPTION
The script `tests/analyze_eigensnp_results.py` was failing with a KeyError if the 'ErrorMessage' column was not present in the input TSV files when generating the markdown report for failed tests.

This commit updates the script to conditionally include the 'ErrorMessage' column in the report only if it exists in the DataFrame. This prevents the script from crashing and ensures the analysis report is generated even if this column is absent.

No specific YAML errors were found in the CI workflow file after review.