### PR TITLE
Fix: Improve caching for CI build dependencies

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,9 +70,9 @@ jobs:
           path: |
             /var/cache/apt/archives
             /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-gfortran-${{ hashFiles('**/rust.yml') }}
+          key: ${{ runner.os }}-apt-gfortran-key-gfortran-v1
           restore-keys: |
-            ${{ runner.os }}-apt-gfortran-
+            ${{ runner.os }}-apt-gfortran-key-gfortran-v1
 
       - name: Install Fortran compiler
         if: matrix.backend == 'openblas' || matrix.backend == 'faer'
@@ -98,9 +98,9 @@ jobs:
           path: |
             /var/cache/apt/archives
             /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-mkl-${{ hashFiles('**/rust.yml') }}
+          key: ${{ runner.os }}-apt-mkl-key-mkl-v1
           restore-keys: |
-            ${{ runner.os }}-apt-mkl-
+            ${{ runner.os }}-apt-mkl-key-mkl-v1
 
       - name: Install Intel MKL
         if: matrix.backend == 'mkl'


### PR DESCRIPTION
This change enhances the caching strategy within the GitHub Actions workflow (`rust.yml`) to reduce unnecessary recompilations and redownloads:

- Modified cache keys for gfortran and Intel MKL: The cache keys for downloaded apt packages (gfortran, Intel MKL) were previously tied to the hash of the entire `rust.yml` workflow file. This caused the cache to be invalidated even for unrelated workflow modifications. The keys have been updated to use static versioned strings (e.g., `key-gfortran-v1`, `key-mkl-v1`). This ensures these dependencies are only refetched if their specific caching key version is manually updated, making the caching of these large downloads more stable and effective.

- Verified Cargo target directory caching: Confirmed that the existing caching mechanism for the Cargo `target` directory, specifically its use of `restore-keys` based on `Cargo.toml` and `Cargo.lock`, adequately allows Cargo to reuse already-compiled dependencies even when the project's own source code changes. This addresses the core requirement of caching dependencies across builds with only source code modifications.