### PR TITLE
feat: Cache MKL installation directory in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -82,6 +82,16 @@ jobs:
           fi
           sudo apt-get install -y gfortran
 
+      - name: Cache MKL installation directory
+        uses: actions/cache@v4
+        id: cache-mkl-installation # Important: This ID is used in the next step
+        if: matrix.backend == 'mkl'
+        with:
+          path: /opt/intel/oneapi
+          key: ${{ runner.os }}-mkl-installation-v1-${{ matrix.backend }}
+          restore-keys: |
+            ${{ runner.os }}-mkl-installation-v1-${{ matrix.backend }}
+
       - name: Setup Intel MKL Repository
         if: matrix.backend == 'mkl'
         run: |
@@ -90,25 +100,20 @@ jobs:
           echo "deb [signed-by=/usr/share/keyrings/intel-archive-keyring.gpg] https://apt.repos.intel.com/oneapi all main" | 
             sudo tee /etc/apt/sources.list.d/oneAPI.list
 
-      - name: Cache Intel MKL apt package
-        uses: actions/cache@v4
-        id: cache-mkl
-        if: matrix.backend == 'mkl'
-        with:
-          path: |
-            /var/cache/apt/archives
-            /var/lib/apt/lists
-          key: ${{ runner.os }}-apt-mkl-key-mkl-v1
-          restore-keys: |
-            ${{ runner.os }}-apt-mkl-key-mkl-v1
-
       - name: Install Intel MKL
         if: matrix.backend == 'mkl'
         run: |
-          if [[ "${{ steps.cache-mkl.outputs.cache-hit }}" != 'true' ]]; then
-            sudo apt-get update -qq
+          if [[ "${{ steps.cache-mkl-installation.outputs.cache-hit }}" != 'true' ]]; then
+            echo "MKL installation cache MISS. Installing MKL via apt..."
+            # apt-get update is needed here because "Setup Intel MKL Repository" (which runs before this)
+            # adds a new repository, and apt needs to be aware of its contents.
+            sudo apt-get update -qq 
+            sudo apt-get install -y intel-oneapi-mkl-devel
+          else
+            echo "MKL installation cache HIT. Skipping apt install."
           fi
-          sudo apt-get install -y intel-oneapi-mkl-devel
+          # These environment variables must always be set for MKL builds.
+          echo "Setting MKL environment variables."
           echo "MKL_ROOT=/opt/intel/oneapi/mkl/latest" >> "$GITHUB_ENV"
           echo "LD_LIBRARY_PATH=/opt/intel/oneapi/mkl/latest/lib/intel64${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}" >> "$GITHUB_ENV"
 


### PR DESCRIPTION
Improves CI performance for the MKL backend by caching the MKL installation directory itself (/opt/intel/oneapi) rather than just the downloaded apt package.

Changes in `.github/workflows/rust.yml`:
- Removed the old `cache-mkl` step that cached apt archives for MKL.
- Added a new `cache-mkl-installation` step using `actions/cache@v4` to cache the `/opt/intel/oneapi` directory. The cache key includes the runner OS and backend type.
- Modified the "Install Intel MKL" step to:
  - Check if the `cache-mkl-installation` was restored.
  - If cache hit, skip `apt-get update` and `apt-get install intel-oneapi-mkl-devel`.
  - If cache miss, perform the `apt-get update` and `install`.
  - Unconditionally set the `MKL_ROOT` and `LD_LIBRARY_PATH` environment variables for the MKL job.

This change should significantly reduce the time taken for MKL setup on cache hits.