### PR TITLE
Fix: Ensure build-failure-flags directory exists in CI

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -240,6 +240,7 @@ jobs:
       - name: Check if any build failure occurred
         id: check-build-failure
         run: |
+          mkdir -p ${{ runner.temp }}/build-failure-flags
           if [[ -n "$(find ${{ runner.temp }}/build-failure-flags -type f -name 'build_failed_*.flag' -print -quit)" ]]; then
             echo "Build failure detected."
             echo "BUILD_FAILED=true" >> $GITHUB_OUTPUT


### PR DESCRIPTION
The 'consolidate-failures' job in the CI workflow was encountering an error when no build failures occurred. This was because the 'actions/download-artifact' action, with 'continue-on-error: true', does not create the destination path if no artifacts are found.

Consequently, the subsequent 'find' command in the 'Check if any build failure occurred' step would fail with a "No such file or directory" error because it was trying to search in a non-existent directory: '${{ runner.temp }}/build-failure-flags'.

This commit fixes the issue by adding 'mkdir -p ${{ runner.temp }}/build-failure-flags' before the 'find' command. This ensures the directory is always present, regardless of whether any failure flag artifacts were downloaded.