### PR TITLE
Fix: Update bincode usage to serde-specific functions

### DIFF
--- a/src/pca.rs
+++ b/src/pca.rs
@@ -867,7 +867,7 @@ impl PCA {
             .map_err(|e| format!("PCA::save_model: Failed to create file at {:?}: {}", path.as_ref(), e))?;
         let mut writer = BufWriter::new(file); 
         
-        bincode::serialize_into(&mut writer, self)
+        bincode::serde::encode_into_std_write(self, &mut writer, bincode::config::standard())
             .map_err(|e| format!("PCA::save_model: Failed to serialize PCA model: {}", e))?;
         Ok(())
     }
@@ -885,7 +885,7 @@ impl PCA {
             .map_err(|e| format!("PCA::load_model: Failed to open file at {:?}: {}", path.as_ref(), e))?;
         let mut reader = BufReader::new(file); 
         
-        let pca_model: PCA = bincode::deserialize_from(&mut reader)
+        let pca_model: PCA = bincode::serde::decode_from_std_read(&mut reader, bincode::config::standard())
             .map_err(|e| format!("PCA::load_model: Failed to deserialize PCA model: {}", e))?;
 
         let rotation = pca_model.rotation.as_ref().ok_or("PCA::load_model: Loaded PCA model is missing rotation matrix.")?;


### PR DESCRIPTION
The bincode crate (v2) requires using functions from the `bincode::serde` module when working with types that derive `serde::Serialize` and `serde::Deserialize`.

This commit updates the `save_model` and `load_model` functions in `src/pca.rs` to use `bincode::serde::encode_into_std_write` and `bincode::serde::decode_from_std_read` respectively. It also passes `bincode::config::standard()` as required by the new API.

This resolves the compilation errors related to `serialize_into` and `deserialize_from` not being found in the `bincode` crate.