### PR TITLE
I've fixed the diagnostics build errors and warnings for the MKL back…

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -1,7 +1,7 @@
 // src/diagnostics.rs
 #![cfg(feature = "enable-eigensnp-diagnostics")]
 
-use ndarray::{s, Array1, Array2, ArrayView1, ArrayView2, Axis, Ix2};
+use ndarray::{Array2, ArrayView1, ArrayView2};
 use crate::linalg_backends::LinAlgBackendProvider; // SVDOutput might not be needed directly
 use serde::{Serialize, Deserialize};
 use std::f64::INFINITY;
@@ -156,7 +156,7 @@ pub fn compute_condition_number_via_svd_f64(matrix: &ArrayView2<f64>) -> Option<
     }
 
     let backend_f64 = LinAlgBackendProvider::<f64>::new();
-    let svd_result = backend_f64.svd_s(matrix.to_owned(), false, false);
+    let svd_result = backend_f64.svd_into(matrix.to_owned(), false, false);
     
     let singular_values = match svd_result {
         Ok(output) => output.s,
@@ -355,7 +355,7 @@ pub fn sample_singular_values(s_values: &ArrayView1<f32>, count: usize) -> Optio
     
     // Add the last element
     sampled.push(s_values[len - 1]);
-    sampled.dedup_by(|a, b| (a - b).abs() < 1e-7); // Adjusted epsilon for f32
+    sampled.dedup_by(|a, b| (*a - *b).abs() < 1e-7); // Adjusted epsilon for f32
     
     Some(sampled)
 }
@@ -441,7 +441,7 @@ pub fn sample_singular_values_f64(s_values: &ArrayView1<f64>, count: usize) -> O
         final_sampled.push(s_values[len - 1]); // Last value
     }
     
-    final_sampled.dedup_by(|a, b| (a - b).abs() < 1e-9); // Keep unique values, f64 comparison
+    final_sampled.dedup_by(|a, b| (*a - *b).abs() < 1e-9); // Keep unique values, f64 comparison
 
     // If dedup resulted in fewer than count, it means some values were very close.
     // This is usually fine. If a strict `count` is needed even with duplicates, remove dedup.


### PR DESCRIPTION
…end.

This update addresses several compilation errors and warnings that occurred when building with the 'enable-eigensnp-diagnostics' and 'backend_mkl' features active.

Here's a summary of the key changes I made:
- I corrected the scoping of `per_block_diag_entry_for_map` in `src/eigensnp.rs` to ensure it's defined in all necessary paths.
- I removed genuinely unused imports from `src/diagnostics.rs`.
- I replaced a call to a non-existent `svd_s` method with `svd_into` in `src/diagnostics.rs`.
- I fixed subtraction errors on references in `dedup_by` calls in `src/diagnostics.rs` by dereferencing values.
- I added `mut` to several function parameters in `src/eigensnp.rs` to allow mutable borrowing of diagnostic collectors.
- I resolved "borrow of moved value" errors in `src/eigensnp.rs` by:
    - Moving diagnostic data captures to before variables are consumed/moved.
    - Cloning data (`projected_b_l_actual_by_n`) when passed to consuming functions if the original is still needed.
- I addressed "unused variable" warnings by prefixing parameters with underscores where appropriate in public wrapper functions in `src/eigensnp.rs`.
- I fixed an E0501 error (closure capturing mutable borrow) in `_internal_perform_rsvd` by refactoring the `push_diag` closure to take the diagnostics collector as an explicit argument at call sites.
- I ensured `mkl-src` is not listed as a direct dependency or in the `backend_mkl` feature definition in `Cargo.toml`, relying on `ndarray-linalg/intel-mkl-static` for MKL linkage.

These changes should allow the diagnostics-specific build to compile successfully with the MKL backend.