### PR TITLE
Update GitHub Actions workflow to prevent concurrent runs

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,5 +1,9 @@
 name: Rust CI
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
This change adds a concurrency group to the CI workflow. The workflow will now cancel any in-progress runs on the same branch when a new commit is pushed. This prevents multiple workflow runs from executing simultaneously for the same branch, saving resources and avoiding potential conflicts.