### PR TITLE
Fix: Resolve E0596 for diagnostics_collector_vec in _internal_perform…

### DIFF
--- a/src/diagnostics.rs
+++ b/src/diagnostics.rs
@@ -407,21 +407,6 @@ pub fn sample_singular_values_f64(s_values: &ArrayView1<f64>, count: usize) -> O
             }
         }
     }
-    // If due to rounding, we don't have enough, fill from end or distinct values?
-    // The current logic aims for distinct points. If rounding causes fewer than `count` unique points,
-    // it might return fewer. This might be acceptable.
-    // A simpler strategy:
-    // sampled.push(s_values[0]);
-    // for i in 1..(count - 1) { sampled.push(s_values[ (i * (len -1) / (count-1)) as usize]); }
-    // if count > 1 { sampled.push(s_values[len-1]); }
-    // sampled.dedup(); // if strict unique values are needed and order matters less for duplicates.
-
-    // Re-implementing sampling logic for clarity and correctness:
-    // This initial block of code for f64 was a bit messy with multiple return paths.
-    // The logic below is cleaner.
-    // if count == 1 && len > 0 { return Some(vec![s_values[0]]); } // Covered by general logic if count=1
-    // if count >= len { return Some(s_values.to_vec()); } // Covered by general logic
-
     let len = s_values.len(); // Original length
     if count == 0 || len == 0 { return Some(Vec::new());}
     if count >= len { return Some(s_values.to_vec()); } // If asking for more or equal to available, return all

--- a/src/eigensnp.rs
+++ b/src/eigensnp.rs
@@ -546,7 +546,7 @@ impl EigenSNPCoreAlgorithm {
             }
         }
 
-        // When diagnostics are not enabled, diagnostics_collector is not declared.
+        // When 'enable-eigensnp-diagnostics' is not enabled, the 'diagnostics_collector' variable is not compiled.
         // The return type PcaOutputWithDiagnostics correctly becomes (EigenSNPCoreOutput, ()),
         // and the () is provided directly in return statements for that configuration.
 
@@ -850,7 +850,7 @@ impl EigenSNPCoreAlgorithm {
         genotype_data: &G,
         ld_block_specs: &[LdBlockSpecification],
         subset_sample_ids: &[QcSampleId],
-        #[cfg(feature = "enable-eigensnp-diagnostics")] diagnostics_collector: Option<&mut Vec<crate::diagnostics::PerBlockLocalBasisDiagnostics>>,
+        #[cfg(feature = "enable-eigensnp-diagnostics")] mut diagnostics_collector: Option<&mut Vec<crate::diagnostics::PerBlockLocalBasisDiagnostics>>, // Added mut
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector_param: Option<()>, // Renamed to avoid conflict
     ) -> Result<Vec<LocalBasisWithDiagnostics>, ThreadSafeStdError> {
         info!(
@@ -913,7 +913,7 @@ impl EigenSNPCoreAlgorithm {
                     {
                         if diagnostics_collector.is_some() && self.config.collect_diagnostics {
                             let (r,c) = genotype_block_for_subset_samples.dim();
-                            per_block_diag_entry_for_map.input_x_s_p_dims = Some((r,c)); // New field perhaps, or update u_p_dims if X_s_p is U_p initially
+                            per_block_diag_entry_for_map.input_x_s_p_dims = Some((r,c));
                             per_block_diag_entry_for_map.notes.push_str(&format!(", X_s_p dims: ({}, {})", r, c));
                             if !genotype_block_for_subset_samples.is_empty() {
                                 per_block_diag_entry_for_map.input_x_s_p_fro_norm = Some(compute_frob_norm_f32(&genotype_block_for_subset_samples.view()) as f64);
@@ -1038,9 +1038,11 @@ impl EigenSNPCoreAlgorithm {
             .collect();
         
         // Separate results and diagnostics
-        let mut collected_diagnostics_entries = Vec::new(); // Temp vec for diagnostics if collected
-
         let mut final_results_tuples = Vec::with_capacity(local_bases_results.len());
+
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        let mut collected_diagnostics_entries: Vec<crate::diagnostics::PerBlockLocalBasisDiagnostics> = Vec::new();
+
         for result_item_tuple in local_bases_results {
             // Each item in local_bases_results is Result<(PerBlockLocalSnpBasis, ActualDiagType), ThreadSafeStdError>>
             // where ActualDiagType is PerBlockLocalBasisDiagnostics or ()
@@ -1049,7 +1051,10 @@ impl EigenSNPCoreAlgorithm {
             #[cfg(feature = "enable-eigensnp-diagnostics")]
             {
                 // Here, diag_entry_for_this_block is PerBlockLocalBasisDiagnostics
-                if diagnostics_collector.is_some() && self.config.collect_diagnostics {
+                // Ensure self.config.collect_diagnostics is the primary guard.
+                // The diagnostics_collector.is_some() check is also good to ensure it's not None
+                // if self.config.collect_diagnostics was true but initialization somehow failed (though less likely).
+                if self.config.collect_diagnostics && diagnostics_collector.is_some() {
                     collected_diagnostics_entries.push(diag_entry_for_this_block.clone()); // Clone and store
                 }
             }
@@ -1063,10 +1068,11 @@ impl EigenSNPCoreAlgorithm {
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         {
-            if let Some(dc_vec_mut) = diagnostics_collector.as_mut() {
-                 if self.config.collect_diagnostics {
+            // Ensure this whole block is guarded by self.config.collect_diagnostics as well
+            if self.config.collect_diagnostics {
+                if let Some(dc_vec_mut) = diagnostics_collector.as_mut() {
                     dc_vec_mut.extend(collected_diagnostics_entries);
-                 }
+                }
             }
         }
 
@@ -1245,13 +1251,7 @@ impl EigenSNPCoreAlgorithm {
                  if self.config.collect_diagnostics {
                     gdc.stage_name = "GlobalPCA_Initial".to_string();
                     // Record A_eigen_std_star (a_c) properties
-                    // gdc.a_eigen_std_dims = Some(a_c.dim()); // This field does not exist in GlobalPcaDiagnostics, use rsvd_stages[0].input_matrix_dims
                     if !a_c.is_empty() {
-                        // gdc.a_eigen_std_fro_norm = Some(compute_frob_norm_f32(&a_c.view()) as f64); // This field does not exist
-                        // gdc.a_eigen_std_condition_number_f32 = compute_condition_number_via_svd_f32(&a_c.view()); // This field does not exist
-                        // let a_c_f64 = a_c.mapv(|v| v as f64);
-                        // gdc.a_eigen_std_condition_number_f64 = compute_condition_number_via_svd_f64(&a_c_f64.view()); // This field does not exist
-                        
                         // Storing these in the first RsvdStepDetail for now
                         let mut first_step_detail = RsvdStepDetail::default();
                         first_step_detail.step_name = "Input_A_eigen_std".to_string();
@@ -1378,13 +1378,6 @@ impl EigenSNPCoreAlgorithm {
         #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector: Option<&mut Vec<crate::diagnostics::RsvdStepDetail>>,
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector: Option<()>,
     ) -> Result<Array2<f32>, ThreadSafeStdError> {
-        // Example of how this would create a step and pass it down:
-        // let mut step_diag = if self.config.collect_diagnostics && diagnostics_collector.is_some() {
-        //     Some(RsvdStepDiagnostics { step_name: "perform_randomized_svd_for_scores_internal".to_string(), ..Default::default() })
-        // } else {
-        //     None
-        // };
-
         let (_u_opt, _s_opt, v_opt) = Self::_internal_perform_rsvd(
             matrix_features_by_samples,
             num_components_target_k,
@@ -1394,8 +1387,8 @@ impl EigenSNPCoreAlgorithm {
             false, // request_u_components
             false, // request_s_components
             true,  // request_v_components
-            #[cfg(feature = "enable-eigensnp-diagnostics")] None, // Placeholder for now
-            #[cfg(not(feature = "enable-eigensnp-diagnostics"))] None, // Pass Option::<()>::None if not enabled
+            #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector,
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector,
         )?;
         
         // if let (Some(collector), Some(diag)) = (diagnostics_collector, step_diag) {
@@ -1421,12 +1414,6 @@ impl EigenSNPCoreAlgorithm {
         #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector: Option<&mut Vec<crate::diagnostics::RsvdStepDetail>>,
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector: Option<()>,
     ) -> Result<Array2<f32>, ThreadSafeStdError> {
-        // let mut step_diag = if self.config.collect_diagnostics && diagnostics_collector.is_some() {
-        //     Some(RsvdStepDiagnostics { step_name: "perform_randomized_svd_for_loadings_internal".to_string(), ..Default::default() })
-        // } else {
-        //     None
-        // };
-
         let (u_opt, _s_opt, _v_opt) = Self::_internal_perform_rsvd(
             matrix_features_by_samples,
             num_components_target_k,
@@ -1436,8 +1423,8 @@ impl EigenSNPCoreAlgorithm {
             true,  // request_u_components
             false, // request_s_components
             false, // request_v_components
-            #[cfg(feature = "enable-eigensnp-diagnostics")] None, // Placeholder for now
-            #[cfg(not(feature = "enable-eigensnp-diagnostics"))] None, // Pass Option::<()>::None if not enabled
+            #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector,
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector,
         )?;
 
         // if let (Some(collector), Some(diag)) = (diagnostics_collector, step_diag) {
@@ -1951,15 +1938,15 @@ impl EigenSNPCoreAlgorithm {
         request_u_components: bool, // True if U (left singular vectors) is needed
         request_s_components: bool, // True if S (singular values) is needed
         request_v_components: bool,  // True if V (right singular vectors) is needed
-        #[cfg(feature = "enable-eigensnp-diagnostics")] mut diagnostics_collector_vec: Option<&mut Vec<crate::diagnostics::RsvdStepDetail>>,
-        #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector_vec: Option<()>, 
+        #[cfg(feature = "enable-eigensnp-diagnostics")] mut diagnostics_collector_vec: Option<&mut Vec<crate::diagnostics::RsvdStepDetail>>, // Added mut back
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector_vec: Option<()>, // Reverted name
     ) -> Result<(Option<Array2<f32>>, Option<Array1<f32>>, Option<Array2<f32>>), ThreadSafeStdError> {
         
         #[cfg(feature = "enable-eigensnp-diagnostics")]
-        let push_diag_fn = |dc_vec_opt: Option<&mut Vec<RsvdStepDetail>>, step_name: String, iteration: Option<usize>, input_dims: Option<(usize,usize)>, output_dims: Option<(usize,usize)>, matrix_to_measure: Option<&ArrayView2<f32>>, q_factor_to_measure: Option<&ArrayView2<f32>>| {
-            if let Some(dc_vec) = dc_vec_opt { // dc_vec is &mut Vec<RsvdStepDetail>
-                let mut detail = RsvdStepDetail::default();
-                detail.step_name = step_name;
+        let push_diag_fn = |dc_vec: &mut Vec<RsvdStepDetail>, step_name: String, iteration: Option<usize>, input_dims: Option<(usize,usize)>, output_dims: Option<(usize,usize)>, matrix_to_measure: Option<&ArrayView2<f32>>, q_factor_to_measure: Option<&ArrayView2<f32>>| {
+            // dc_vec is now &mut Vec<RsvdStepDetail> directly
+            let mut detail = RsvdStepDetail::default();
+            detail.step_name = step_name;
                 if let Some(iter) = iteration { detail.notes = format!("Iteration: {}", iter); }
                 detail.input_matrix_dims = input_dims;
                 detail.output_matrix_dims = output_dims;
@@ -1976,18 +1963,29 @@ impl EigenSNPCoreAlgorithm {
                     }
                 }
                 dc_vec.push(detail);
-            }
+            // Removed if let Some(dc_vec) = dc_vec_opt wrapper
         };
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        let push_diag_fn = |_: Option<&mut ()>, _: String, _: Option<usize>, _: Option<(usize,usize)>, _: Option<(usize,usize)>, _: Option<&ArrayView2<f32>>, _: Option<&ArrayView2<f32>>| {
+        let push_diag_fn = |_: Option<()>, _: String, _: Option<usize>, _: Option<(usize,usize)>, _: Option<(usize,usize)>, _: Option<&ArrayView2<f32>>, _: Option<&ArrayView2<f32>>| { // This signature is correct for non-diagnostic
             // No-op for non-diagnostics build
         };
 
         let num_features_m = matrix_features_by_samples.nrows();
         let num_samples_n = matrix_features_by_samples.ncols();
 
-        // Call the new closure, passing diagnostics_collector_vec.as_mut()
-        push_diag_fn(diagnostics_collector_vec.as_mut(), "Input_A".to_string(), None, None, Some((num_features_m, num_samples_n)), Some(&matrix_features_by_samples.view()), None);
+        // collector_for_push_fn for diagnostic path is removed.
+        // Non-diagnostic collector_for_push_fn remains as is.
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        let collector_for_push_fn = _diagnostics_collector_vec;
+
+        // Call the push_diag_fn closure, passing the appropriate collector.
+        // This call needs to be updated per point 4.
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+            push_diag_fn(actual_collector, "Input_A".to_string(), None, None, Some((num_features_m, num_samples_n)), Some(&matrix_features_by_samples.view()), None);
+        }
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        push_diag_fn(collector_for_push_fn, "Input_A".to_string(), None, None, Some((num_features_m, num_samples_n)), Some(&matrix_features_by_samples.view()), None);
 
         if num_features_m == 0 || num_samples_n == 0 || num_components_target_k == 0 {
             debug!("RSVD: Input matrix empty or K=0. M={}, N={}, K={}", num_features_m, num_samples_n, num_components_target_k);
@@ -2025,13 +2023,23 @@ impl EigenSNPCoreAlgorithm {
         let random_projection_matrix_omega = Array2::from_shape_fn((num_samples_n, sketch_dimension_l), |_| {
             normal_dist.sample(&mut rng) as f32
         });
-        push_diag_fn(diagnostics_collector_vec.as_mut(), "Omega".to_string(), None, Some((num_samples_n, sketch_dimension_l)), Some((num_samples_n, sketch_dimension_l)), Some(&random_projection_matrix_omega.view()), None);
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+            push_diag_fn(actual_collector, "Omega".to_string(), None, Some((num_samples_n, sketch_dimension_l)), Some((num_samples_n, sketch_dimension_l)), Some(&random_projection_matrix_omega.view()), None);
+        }
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        push_diag_fn(collector_for_push_fn, "Omega".to_string(), None, Some((num_samples_n, sketch_dimension_l)), Some((num_samples_n, sketch_dimension_l)), Some(&random_projection_matrix_omega.view()), None);
         
         let backend = LinAlgBackendProvider::<f32>::new();
         
         // Y = A * Omega (M x N) * (N x L) -> (M x L)
         let sketch_y = Self::dot_product_mixed_precision_f32_f64acc(matrix_features_by_samples, &random_projection_matrix_omega.view())?;
-        push_diag_fn(diagnostics_collector_vec.as_mut(), "SketchY_PreQR".to_string(), None, Some((num_features_m, num_samples_n)), Some(sketch_y.dim()), Some(&sketch_y.view()), None);
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+            push_diag_fn(actual_collector, "SketchY_PreQR".to_string(), None, Some((num_features_m, num_samples_n)), Some(sketch_y.dim()), Some(&sketch_y.view()), None);
+        }
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        push_diag_fn(collector_for_push_fn, "SketchY_PreQR".to_string(), None, Some((num_features_m, num_samples_n)), Some(sketch_y.dim()), Some(&sketch_y.view()), None);
 
 
         if sketch_y.ncols() == 0 {
@@ -2045,7 +2053,12 @@ impl EigenSNPCoreAlgorithm {
         // Q_basis = orth(Y) (M x L_actual_y)
         let mut q_basis_m_by_l_actual = backend.qr_q_factor(&sketch_y)
             .map_err(|e_qr| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("QR decomposition of initial sketch Y failed in RSVD: {}", e_qr))) as ThreadSafeStdError)?;
-        push_diag_fn(diagnostics_collector_vec.as_mut(), "Q0_PostQR".to_string(), Some(0), Some(sketch_y.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+            push_diag_fn(actual_collector, "Q0_PostQR".to_string(), Some(0), Some(sketch_y.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
+        }
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        push_diag_fn(collector_for_push_fn, "Q0_PostQR".to_string(), Some(0), Some(sketch_y.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
         
         // Power iterations
         for iter_idx in 0..num_power_iterations {
@@ -2057,7 +2070,12 @@ impl EigenSNPCoreAlgorithm {
             
             // Q_tilde_candidate = A.T * Q_basis (N x M) * (M x L_actual) -> (N x L_actual)
             let q_tilde_candidate = Self::dot_product_at_b_mixed_precision(matrix_features_by_samples, &q_basis_m_by_l_actual.view())?;
-            push_diag_fn(diagnostics_collector_vec.as_mut(), format!("PowerIter{}_Ytilde_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_m_by_l_actual.dim()), Some(q_tilde_candidate.dim()), Some(&q_tilde_candidate.view()), None);
+            #[cfg(feature = "enable-eigensnp-diagnostics")]
+            if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+                push_diag_fn(actual_collector, format!("PowerIter{}_Ytilde_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_m_by_l_actual.dim()), Some(q_tilde_candidate.dim()), Some(&q_tilde_candidate.view()), None);
+            }
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Ytilde_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_m_by_l_actual.dim()), Some(q_tilde_candidate.dim()), Some(&q_tilde_candidate.view()), None);
 
             if q_tilde_candidate.ncols() == 0 { 
                 q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(),0)); 
@@ -2067,7 +2085,12 @@ impl EigenSNPCoreAlgorithm {
             // Q_tilde = orth(Q_tilde_candidate) (N x L_actual_tilde)
             let q_tilde_n_by_l_actual = backend.qr_q_factor(&q_tilde_candidate)
                 .map_err(|e_qr| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("QR for Q_tilde in power iteration {} failed: {}", iter_idx + 1, e_qr))) as ThreadSafeStdError)?;
-            push_diag_fn(diagnostics_collector_vec.as_mut(), format!("PowerIter{}_Qtilde_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_candidate.dim()), Some(q_tilde_n_by_l_actual.dim()), None, Some(&q_tilde_n_by_l_actual.view()));
+            #[cfg(feature = "enable-eigensnp-diagnostics")]
+            if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+                push_diag_fn(actual_collector, format!("PowerIter{}_Qtilde_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_candidate.dim()), Some(q_tilde_n_by_l_actual.dim()), None, Some(&q_tilde_n_by_l_actual.view()));
+            }
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Qtilde_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_candidate.dim()), Some(q_tilde_n_by_l_actual.dim()), None, Some(&q_tilde_n_by_l_actual.view()));
 
             if q_tilde_n_by_l_actual.ncols() == 0 {
                 q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(),0));
@@ -2077,7 +2100,12 @@ impl EigenSNPCoreAlgorithm {
 
             // Q_basis_candidate = A * Q_tilde (M x N) * (N x L_actual_tilde) -> (M x L_actual_tilde)
             let q_basis_candidate_next = Self::dot_product_mixed_precision_f32_f64acc(matrix_features_by_samples, &q_tilde_n_by_l_actual.view())?;
-            push_diag_fn(diagnostics_collector_vec.as_mut(), format!("PowerIter{}_Ynext_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_n_by_l_actual.dim()), Some(q_basis_candidate_next.dim()), Some(&q_basis_candidate_next.view()), None);
+            #[cfg(feature = "enable-eigensnp-diagnostics")]
+            if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+                push_diag_fn(actual_collector, format!("PowerIter{}_Ynext_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_n_by_l_actual.dim()), Some(q_basis_candidate_next.dim()), Some(&q_basis_candidate_next.view()), None);
+            }
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Ynext_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_n_by_l_actual.dim()), Some(q_basis_candidate_next.dim()), Some(&q_basis_candidate_next.view()), None);
 
             if q_basis_candidate_next.ncols() == 0 {
                  q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(),0));
@@ -2087,7 +2115,12 @@ impl EigenSNPCoreAlgorithm {
             // Q_basis = orth(Q_basis_candidate_next) (M x L_actual_final_iter)
             q_basis_m_by_l_actual = backend.qr_q_factor(&q_basis_candidate_next)
                 .map_err(|e_qr| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("QR for Q_basis in power iteration {} failed: {}", iter_idx + 1, e_qr))) as ThreadSafeStdError)?;
-            push_diag_fn(diagnostics_collector_vec.as_mut(), format!("PowerIter{}_Qnext_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_candidate_next.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
+            #[cfg(feature = "enable-eigensnp-diagnostics")]
+            if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+                push_diag_fn(actual_collector, format!("PowerIter{}_Qnext_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_candidate_next.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
+            }
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Qnext_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_candidate_next.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
         }
         
         if q_basis_m_by_l_actual.ncols() == 0 {
@@ -2100,7 +2133,12 @@ impl EigenSNPCoreAlgorithm {
         
         // B = Q_basis.T * A (L_actual x M) * (M x N) -> (L_actual x N)
         let projected_b_l_actual_by_n = Self::dot_product_at_b_mixed_precision(&q_basis_m_by_l_actual.view(), matrix_features_by_samples)?;
-        push_diag_fn(diagnostics_collector_vec.as_mut(), "ProjectedB_PreSVD".to_string(), None, Some(q_basis_m_by_l_actual.dim()), Some(projected_b_l_actual_by_n.dim()), Some(&projected_b_l_actual_by_n.view()), None);
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+            push_diag_fn(actual_collector, "ProjectedB_PreSVD".to_string(), None, Some(q_basis_m_by_l_actual.dim()), Some(projected_b_l_actual_by_n.dim()), Some(&projected_b_l_actual_by_n.view()), None);
+        }
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        push_diag_fn(collector_for_push_fn, "ProjectedB_PreSVD".to_string(), None, Some(q_basis_m_by_l_actual.dim()), Some(projected_b_l_actual_by_n.dim()), Some(&projected_b_l_actual_by_n.view()), None);
         
         // SVD of B: B = U_B * S_B * V_B.T
         // U_B is L_actual x rank_b
@@ -2142,8 +2180,8 @@ impl EigenSNPCoreAlgorithm {
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         {
-            if let Some(dc_vec) = diagnostics_collector_vec.as_mut() {
-                // Assuming self.config.collect_diagnostics is checked by the caller
+            if let Some(ref mut dc_vec) = diagnostics_collector_vec { // Changed to use diagnostics_collector_vec and ref mut
+                // dc_vec is now &mut Vec<RsvdStepDetail>
                 let mut detail_svd = RsvdStepDetail::default();
                 detail_svd.step_name = "SVD_of_B".to_string();
                 if let Some(u_b) = svd_output_b.u.as_ref() { 
@@ -2204,7 +2242,12 @@ impl EigenSNPCoreAlgorithm {
                     // U_A = Q_basis * U_B (M x L_actual) * (L_actual x rank_b) -> M x rank_b
                     let u_a_approx_m_by_rank_b = q_basis_m_by_l_actual.dot(&u_b_l_actual_by_rank_b);
                     let u_a_final = u_a_approx_m_by_rank_b.slice_axis(Axis(1), ndarray::Slice::from(0..num_k_to_return)).to_owned();
-                    push_diag_fn(diagnostics_collector_vec.as_mut(), "Final_U_A".to_string(), None, Some(u_a_approx_m_by_rank_b.dim()), Some(u_a_final.dim()), Some(&u_a_final.view()), Some(&u_a_final.view())); // Ortho error for U_A
+                    #[cfg(feature = "enable-eigensnp-diagnostics")]
+                    if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+                        push_diag_fn(actual_collector, "Final_U_A".to_string(), None, Some(u_a_approx_m_by_rank_b.dim()), Some(u_a_final.dim()), Some(&u_a_final.view()), Some(&u_a_final.view()));
+                    }
+                    #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+                    push_diag_fn(collector_for_push_fn, "Final_U_A".to_string(), None, Some(u_a_approx_m_by_rank_b.dim()), Some(u_a_final.dim()), Some(&u_a_final.view()), Some(&u_a_final.view()));
                     u_a_approx_opt = Some(u_a_final);
                 } else {
                      u_a_approx_opt = Some(Array2::zeros((num_features_m, 0)));   
@@ -2220,7 +2263,12 @@ impl EigenSNPCoreAlgorithm {
                     // V_A = V_B. V_B is (N x rank_b). We have V_B.T (rank_b x N)
                     let v_a_approx_n_by_rank_b = v_b_t_rank_b_by_n.t().into_owned();
                     let v_a_final = v_a_approx_n_by_rank_b.slice_axis(Axis(1), ndarray::Slice::from(0..num_k_to_return)).to_owned();
-                    push_diag_fn(diagnostics_collector_vec.as_mut(), "Final_V_A".to_string(), None, Some(v_a_approx_n_by_rank_b.dim()), Some(v_a_final.dim()), Some(&v_a_final.view()), Some(&v_a_final.view())); // Ortho error for V_A
+                    #[cfg(feature = "enable-eigensnp-diagnostics")]
+                    if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+                        push_diag_fn(actual_collector, "Final_V_A".to_string(), None, Some(v_a_approx_n_by_rank_b.dim()), Some(v_a_final.dim()), Some(&v_a_final.view()), Some(&v_a_final.view()));
+                    }
+                    #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+                    push_diag_fn(collector_for_push_fn, "Final_V_A".to_string(), None, Some(v_a_approx_n_by_rank_b.dim()), Some(v_a_final.dim()), Some(&v_a_final.view()), Some(&v_a_final.view()));
                     v_a_approx_opt = Some(v_a_final);
                 } else {
                     v_a_approx_opt = Some(Array2::zeros((num_samples_n, 0)));


### PR DESCRIPTION
…_rsvd

This commit addresses the E0596 error ("cannot borrow as mutable") for the `diagnostics_collector_vec` parameter in the diagnostic build path of the `_internal_perform_rsvd` function.

The `diagnostics_collector_vec` parameter in the function signature, when `enable-eigensnp-diagnostics` is active, is now declared as `mut`. This allows `if let Some(ref mut actual_collector) = diagnostics_collector_vec` to correctly borrow the contents of the Option mutably.

This was the last identified compilation error for the diagnostic build. The non-diagnostic build was reported as compiling correctly prior to this change.