### PR TITLE
Fix: Import ndarray::ShapeBuilder in faer_specific_code

### DIFF
--- a/src/linalg_backends.rs
+++ b/src/linalg_backends.rs
@@ -148,6 +148,7 @@ mod faer_specific_code { // Encapsulate faer-specific code and its imports
     use faer::traits::ComplexField;
     use bytemuck::Pod;
     use std::error::Error;
+    use ndarray::ShapeBuilder;
     
     // Updated imports for SVD
     // use faer::Parallelism; // No longer needed


### PR DESCRIPTION
The `f` method, used to specify Fortran-order for ndarray shapes, was not in scope in the `faer_specific_code` module. This was causing compiler errors E0599.

This commit fixes the issue by adding `use ndarray::ShapeBuilder;` to the `faer_specific_code` module in `src/linalg_backends.rs`.