### PR TITLE
Fix: Specify SIMD lane count for zero_simd

### DIFF
--- a/src/eigensnp.rs
+++ b/src/eigensnp.rs
@@ -347,7 +347,7 @@ fn standardize_raw_condensed_features(
                     row_data_mut_slice[idx] *= inv_std_dev_val;
                 }
             } else {
-                let zero_simd = Simd::splat(0.0f32);
+                let zero_simd = Simd::<f32, LANES>::splat(0.0f32);
                 for chunk_idx in 0..num_simd_chunks {
                     let offset = chunk_idx * LANES;
                     zero_simd.copy_to_slice(&mut row_data_mut_slice[offset .. offset + LANES]);


### PR DESCRIPTION
The compiler was unable to infer the number of lanes for `zero_simd` in `standardize_raw_condensed_features` when a feature row had near-zero standard deviation.

This commit explicitly specifies the lane count using the `LANES` constant, which is defined in the same function scope (as 8).

The line:
let zero_simd = Simd::splat(0.0f32);

was changed to:
let zero_simd = Simd::<f32, LANES>::splat(0.0f32);

This resolves compilation error E0284.