### PR TITLE
Add optional local PC loading extraction

### DIFF
--- a/benches/benchmarks.rs
+++ b/benches/benchmarks.rs
@@ -6,14 +6,14 @@ use jemallocator::Jemalloc;
 #[global_allocator]
 static GLOBAL: Jemalloc = Jemalloc;
 
-use criterion::{criterion_group, criterion_main, Criterion, BenchmarkId, Throughput};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
 use efficient_pca::PCA;
 use ndarray::Array2;
-use rand::distributions::{Uniform};
+use rand::distributions::Uniform;
 use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::fs::File;
-use std::io::{Write, BufWriter};
+use std::io::{BufWriter, Write};
 use std::time::Instant;
 
 #[cfg(all(feature = "jemalloc", not(target_env = "msvc")))]
@@ -32,14 +32,11 @@ enum DataSource {
     },
 }
 
-
 /// Generates random data of shape (n_samples x n_features) with values 0, 1, or 2 (as f64), seeded for reproducibility.
 fn generate_random_data(n_samples: usize, n_features: usize, seed: u64) -> Array2<f64> {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
     let distribution = Uniform::new_inclusive(0, 2);
-    Array2::from_shape_fn((n_samples, n_features), |_| {
-        rng.sample(distribution) as f64
-    })
+    Array2::from_shape_fn((n_samples, n_features), |_| rng.sample(distribution) as f64)
 }
 
 /// Generates sparse random data of shape (n_samples x n_features).
@@ -123,9 +120,8 @@ fn benchmark_pca(
     let mut pca = PCA::new();
     let transformed_data: Array2<f64>;
 
-    let n_components_to_use_for_rfit = n_components_override.unwrap_or_else(|| {
-        std::cmp::min(data.nrows(), data.ncols()).min(30).max(2)
-    });
+    let n_components_to_use_for_rfit = n_components_override
+        .unwrap_or_else(|| std::cmp::min(data.nrows(), data.ncols()).min(30).max(2));
 
     if use_rfit {
         transformed_data = pca
@@ -137,7 +133,11 @@ fn benchmark_pca(
                 None,
             )
             .expect("rfit failed");
-        assert_eq!(transformed_data.ncols(), n_components_to_use_for_rfit, "RFIT: Transformed data column count should match requested components for rfit.");
+        assert_eq!(
+            transformed_data.ncols(),
+            n_components_to_use_for_rfit,
+            "RFIT: Transformed data column count should match requested components for rfit."
+        );
     } else {
         pca.fit(data.clone(), None).expect("fit failed");
         transformed_data = pca.transform(data.clone()).expect("transform failed");
@@ -145,7 +145,11 @@ fn benchmark_pca(
         assert_eq!(transformed_data.ncols(), actual_fit_components, "FIT: Transformed data column count should match actual components in the model after fit.");
     }
 
-    assert_eq!(transformed_data.nrows(), data.nrows(), "Transformed data should have same number of rows as input.");
+    assert_eq!(
+        transformed_data.nrows(),
+        data.nrows(),
+        "Transformed data should have same number of rows as input."
+    );
 
     let duration = start_time.elapsed().as_secs_f64();
 
@@ -164,10 +168,12 @@ fn benchmark_pca(
     let rss_delta_bytes = resident_after.saturating_sub(resident_before);
     let virt_delta_bytes = active_after.saturating_sub(active_before);
 
-    (duration, (rss_delta_bytes / 1024) as u64, (virt_delta_bytes / 1024) as u64) // Convert bytes to KB
+    (
+        duration,
+        (rss_delta_bytes / 1024) as u64,
+        (virt_delta_bytes / 1024) as u64,
+    ) // Convert bytes to KB
 }
-
-
 
 fn write_raw_data_to_tsv(
     raw_data: &[RawBenchDataPoint],
@@ -184,8 +190,9 @@ fn write_raw_data_to_tsv(
 
     // Write data
     for point in raw_data {
-        let n_comp_str = point.n_components_override
-                            .map_or_else(|| "None".to_string(), |k| k.to_string());
+        let n_comp_str = point
+            .n_components_override
+            .map_or_else(|| "None".to_string(), |k| k.to_string());
         writeln!(
             writer,
             "{}	{}	{}	{}	{}	{}	{:.6}	{}	{}	{}", // Using {:.6} for TimeSec for precision
@@ -211,7 +218,7 @@ struct RawBenchDataPoint {
     n_features: usize,
     backend_name: String,
     iteration_idx: u64, // Criterion's iteration count (from 0 to iters-1)
-    run_type: String,    // "fit" or "rfit"
+    run_type: String,   // "fit" or "rfit"
     time_sec: f64,
     rss_delta_kb: u64,
     virt_delta_kb: u64,
@@ -222,18 +229,22 @@ fn determine_appropriate_sample_size(
     scenario_name_short: &str, // e.g., "Large", "Wide", "Small"
     is_rfit: bool,
     _n_samples: usize, // _ to indicate potentially unused for now, but good for context
-    n_features: usize
+    n_features: usize,
 ) -> usize {
-    if !is_rfit { // Fit method
+    if !is_rfit {
+        // Fit method
         match scenario_name_short {
             "Large" | "Square" | "Sparse-W" => return 10,
-            "Wide" | "LowVar-W" | "Wide-k10" | "Wide-k50" | "Wide-k200" if n_features >= 10000 => return 10,
+            "Wide" | "LowVar-W" | "Wide-k10" | "Wide-k50" | "Wide-k200" if n_features >= 10000 => {
+                return 10
+            }
             "Wide-XL" if n_features >= 100000 => return 10,
             "Wide-L" if n_features >= 50000 => return 20,
             "Medium" | "Tall" => return 50,
             _ => return 100, // For "Small" and other faster scenarios
         }
-    } else { // Rfit method
+    } else {
+        // Rfit method
         match scenario_name_short {
             "Wide-k200" if n_features >= 10000 => return 20,
             "Wide-XL" if n_features >= 100000 => return 30,
@@ -245,7 +256,11 @@ fn determine_appropriate_sample_size(
 
 fn criterion_benchmark_runner(c: &mut Criterion) {
     let mut all_raw_data = Vec::<RawBenchDataPoint>::new();
-    let current_backend_name = if cfg!(feature = "backend_faer") { "faer".to_string() } else { "ndarray".to_string() };
+    let current_backend_name = if cfg!(feature = "backend_faer") {
+        "faer".to_string()
+    } else {
+        "ndarray".to_string()
+    };
 
     let scenarios = vec![
         ("Small", 100, 50, 1234, DataSource::Dense012, None),
@@ -256,27 +271,57 @@ fn criterion_benchmark_runner(c: &mut Criterion) {
         ("Wide", 500, 10000, 1234, DataSource::Dense012, None),
         ("Wide-L", 100, 50000, 1234, DataSource::Dense012, None),
         ("Wide-XL", 88, 100000, 1234, DataSource::Dense012, None),
-        ("Sparse-W", 500, 20000, 1234, DataSource::Sparse012(0.95), None),
-        ("LowVar-W", 500, 10000, 1234, DataSource::LowVariance012 { fraction_low_var_feats: 0.5, majority_val_in_low_var_feat: 0.95 }, None),
+        (
+            "Sparse-W",
+            500,
+            20000,
+            1234,
+            DataSource::Sparse012(0.95),
+            None,
+        ),
+        (
+            "LowVar-W",
+            500,
+            10000,
+            1234,
+            DataSource::LowVariance012 {
+                fraction_low_var_feats: 0.5,
+                majority_val_in_low_var_feat: 0.95,
+            },
+            None,
+        ),
         ("Wide-k10", 500, 10000, 1234, DataSource::Dense012, Some(10)),
         ("Wide-k50", 500, 10000, 1234, DataSource::Dense012, Some(50)),
-        ("Wide-k200", 500, 10000, 1234, DataSource::Dense012, Some(200)),
+        (
+            "Wide-k200",
+            500,
+            10000,
+            1234,
+            DataSource::Dense012,
+            Some(200),
+        ),
     ];
-
 
     for (name, n_samples, n_features, seed, data_source_type, n_components_override) in scenarios {
         // Clone data_source_type if it's captured by multiple closures or used after move.
         let data = match data_source_type.clone() {
             DataSource::Dense012 => generate_random_data(n_samples, n_features, seed),
             DataSource::Sparse012(s) => generate_sparse_random_data(n_samples, n_features, s, seed),
-            DataSource::LowVariance012 { fraction_low_var_feats, majority_val_in_low_var_feat } =>
-                generate_low_variance_data(n_samples, n_features, fraction_low_var_feats, majority_val_in_low_var_feat, seed),
+            DataSource::LowVariance012 {
+                fraction_low_var_feats,
+                majority_val_in_low_var_feat,
+            } => generate_low_variance_data(
+                n_samples,
+                n_features,
+                fraction_low_var_feats,
+                majority_val_in_low_var_feat,
+                seed,
+            ),
         };
 
         let oversamples_for_rfit = 0;
 
         // --- FIT Benchmark ---
-
 
         // --- FIT Benchmark ---
         let fit_group_name = format!("fit/{}", name);
@@ -288,16 +333,26 @@ fn criterion_benchmark_runner(c: &mut Criterion) {
 
         let _fit_benchmark_id = BenchmarkId::new(
             "fit", // Use "fit" as function_id
-            format!("{}_s{}_f{}_c{:?}", name, n_samples, n_features, n_components_override) // Parameter string
+            format!(
+                "{}_s{}_f{}_c{:?}",
+                name, n_samples, n_features, n_components_override
+            ), // Parameter string
         );
 
         fit_group.bench_with_input(_fit_benchmark_id, &data.clone(), |b, data_to_bench| {
             b.iter_custom(|iters| {
                 let mut total_duration = std::time::Duration::new(0, 0);
-                for i in 0..iters { // Use 'i' for iteration_idx
-                    let (time_taken, rss_mem_used, virt_mem_used) = benchmark_pca(false, data_to_bench, n_components_override, oversamples_for_rfit, seed);
+                for i in 0..iters {
+                    // Use 'i' for iteration_idx
+                    let (time_taken, rss_mem_used, virt_mem_used) = benchmark_pca(
+                        false,
+                        data_to_bench,
+                        n_components_override,
+                        oversamples_for_rfit,
+                        seed,
+                    );
                     total_duration += std::time::Duration::from_secs_f64(time_taken);
-                    
+
                     all_raw_data.push(RawBenchDataPoint {
                         scenario_name: name.to_string(),
                         n_samples,
@@ -310,13 +365,11 @@ fn criterion_benchmark_runner(c: &mut Criterion) {
                         virt_delta_kb: virt_mem_used,
                         n_components_override,
                     });
-
                 }
                 total_duration
             });
         });
         fit_group.finish();
-        
 
         // --- RFIT Benchmark ---
         let rfit_group_name = format!("rfit/{}", name);
@@ -327,14 +380,24 @@ fn criterion_benchmark_runner(c: &mut Criterion) {
 
         let rfit_benchmark_id = BenchmarkId::new(
             "rfit", // Use "rfit" as function_id
-            format!("{}_s{}_f{}_c{:?}", name, n_samples, n_features, n_components_override) // Parameter string
+            format!(
+                "{}_s{}_f{}_c{:?}",
+                name, n_samples, n_features, n_components_override
+            ), // Parameter string
         );
-        
+
         rfit_group.bench_with_input(rfit_benchmark_id, &data.clone(), |b, data_to_bench| {
-             b.iter_custom(|iters| {
-                let mut total_duration = std::time::Duration::new(0,0);
-                for i in 0..iters { // Use 'i' for iteration_idx
-                    let (time_taken, rss_mem_used, virt_mem_used) = benchmark_pca(true, data_to_bench, n_components_override, oversamples_for_rfit, seed);
+            b.iter_custom(|iters| {
+                let mut total_duration = std::time::Duration::new(0, 0);
+                for i in 0..iters {
+                    // Use 'i' for iteration_idx
+                    let (time_taken, rss_mem_used, virt_mem_used) = benchmark_pca(
+                        true,
+                        data_to_bench,
+                        n_components_override,
+                        oversamples_for_rfit,
+                        seed,
+                    );
                     total_duration += std::time::Duration::from_secs_f64(time_taken);
 
                     all_raw_data.push(RawBenchDataPoint {
@@ -349,15 +412,12 @@ fn criterion_benchmark_runner(c: &mut Criterion) {
                         virt_delta_kb: virt_mem_used,
                         n_components_override,
                     });
-                    
                 }
                 total_duration
             });
         });
         rfit_group.finish();
-
     }
-    
 
     if let Err(e) = write_raw_data_to_tsv(&all_raw_data, "benchmark_raw_results.tsv") {
         eprintln!("Failed to write raw benchmark data to TSV: {}", e);

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,2 @@
+[toolchain]
+channel = "nightly"

--- a/src/eigensnp.rs
+++ b/src/eigensnp.rs
@@ -1,32 +1,32 @@
-use ndarray::{s, Array1, Array2, Axis, ArrayView2};
+use ndarray::{s, Array1, Array2, ArrayView2, Axis};
 // Eigh, QR, SVDInto are replaced by backend calls. UPLO is handled by eigh_upper.
-// use ndarray_linalg::{Eigh, UPLO, QR, SVDInto}; 
+// use ndarray_linalg::{Eigh, UPLO, QR, SVDInto};
 use crate::linalg_backends::{BackendQR, BackendSVD, LinAlgBackendProvider};
 // use crate::ndarray_backend::NdarrayLinAlgBackend; // Replaced by LinAlgBackendProvider
 // use crate::linalg_backend_dispatch::LinAlgBackendProvider; // Now part of linalg_backends
-use rayon::prelude::*;
-use std::simd::prelude::*;
-use std::error::Error;
-use log::{info, debug, trace, warn};
+use log::{debug, info, trace, warn};
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use rand_distr::{Distribution, Normal};
+use rayon::prelude::*;
+use std::error::Error;
+use std::simd::prelude::*;
 // Updated diagnostics struct names
 #[cfg(feature = "enable-eigensnp-diagnostics")]
 use crate::diagnostics::{
-    FullPcaRunDetailedDiagnostics, 
-    RsvdStepDetail, 
-    PerBlockLocalBasisDiagnostics,
-    SrPassDetail,
-    compute_frob_norm_f32, // For f32 matrices
-    compute_frob_norm_f64, // For f64 matrices (if any intermediate become f64)
     compute_condition_number_via_svd_f32, // For f32 matrices, uses f64 SVD
     compute_condition_number_via_svd_f64, // For f64 matrices
-    compute_orthogonality_error_f32, // For Q factors (f32)
-    compute_svd_reconstruction_error_f32, // For SVD steps (f32)
-    sample_singular_values, // For f32 singular values
-    sample_singular_values_f64, // For f64 singular values
+    compute_frob_norm_f32,                // For f32 matrices
+    compute_frob_norm_f64,                // For f64 matrices (if any intermediate become f64)
     compute_matrix_column_correlations_abs, // For f32 vs f64 matrix correlations
+    compute_orthogonality_error_f32,      // For Q factors (f32)
+    compute_svd_reconstruction_error_f32, // For SVD steps (f32)
+    sample_singular_values,               // For f32 singular values
+    sample_singular_values_f64,           // For f64 singular values
+    FullPcaRunDetailedDiagnostics,
+    PerBlockLocalBasisDiagnostics,
+    RsvdStepDetail,
+    SrPassDetail,
 };
 
 /// A thread-safe wrapper for standard dynamic errors,
@@ -65,7 +65,6 @@ pub type LocalBasisWithDiagnostics = (
 
 #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
 pub type LocalBasisWithDiagnostics = (PerBlockLocalSnpBasis, ());
-
 
 // Helper trait for f64 conversion from Duration, handling potential errors.
 #[cfg(feature = "enable-eigensnp-diagnostics")]
@@ -181,8 +180,12 @@ pub struct RawCondensedFeatures {
 }
 
 impl RawCondensedFeatures {
-    pub fn num_total_condensed_features(&self) -> usize { self.data.nrows() }
-    pub fn num_samples(&self) -> usize { self.data.ncols() }
+    pub fn num_total_condensed_features(&self) -> usize {
+        self.data.nrows()
+    }
+    pub fn num_samples(&self) -> usize {
+        self.data.ncols()
+    }
 }
 
 /// Represents the condensed feature matrix (A_eigen_std_star) after its features (rows)
@@ -195,8 +198,12 @@ pub struct StandardizedCondensedFeatures {
 }
 
 impl StandardizedCondensedFeatures {
-    pub fn num_total_condensed_features(&self) -> usize { self.data.nrows() }
-    pub fn num_samples(&self) -> usize { self.data.ncols() }
+    pub fn num_total_condensed_features(&self) -> usize {
+        self.data.nrows()
+    }
+    pub fn num_samples(&self) -> usize {
+        self.data.ncols()
+    }
 }
 
 /// Represents the initial Principal Component scores for all N samples,
@@ -209,8 +216,12 @@ pub struct InitialSamplePcScores {
 }
 
 impl InitialSamplePcScores {
-    pub fn num_samples(&self) -> usize { self.scores.nrows() }
-    pub fn num_pcs_computed(&self) -> usize { self.scores.ncols() }
+    pub fn num_samples(&self) -> usize {
+        self.scores.nrows()
+    }
+    pub fn num_pcs_computed(&self) -> usize {
+        self.scores.ncols()
+    }
 }
 
 // --- Final Output Structure ---
@@ -237,7 +248,6 @@ pub struct EigenSNPCoreOutput {
     pub num_principal_components_computed: usize,
 }
 
-
 // --- Utility Functions ---
 
 /// Standardizes each row (feature) of the input condensed feature matrix to have zero mean and unit variance.
@@ -248,7 +258,9 @@ fn standardize_raw_condensed_features(
     raw_features_input: RawCondensedFeatures,
     #[cfg_attr(not(feature = "enable-eigensnp-diagnostics"), allow(unused_variables))]
     collect_diagnostics_flag: bool,
-    #[cfg(feature = "enable-eigensnp-diagnostics")] mut full_diagnostics_collector: Option<&mut crate::diagnostics::FullPcaRunDetailedDiagnostics>,
+    #[cfg(feature = "enable-eigensnp-diagnostics")] mut full_diagnostics_collector: Option<
+        &mut crate::diagnostics::FullPcaRunDetailedDiagnostics,
+    >,
     #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _full_diagnostics_collector: Option<()>,
 ) -> Result<StandardizedCondensedFeatures, ThreadSafeStdError> {
     let mut condensed_data_matrix = raw_features_input.data;
@@ -268,7 +280,9 @@ fn standardize_raw_condensed_features(
             condensed_data_matrix.fill(0.0f32);
         }
         debug!("Number of samples ({}) is <= 1 for condensed matrix; standardization results in zeros or is skipped if already empty.", num_samples);
-        return Ok(StandardizedCondensedFeatures { data: condensed_data_matrix });
+        return Ok(StandardizedCondensedFeatures {
+            data: condensed_data_matrix,
+        });
     }
 
     // Parallelize row-wise standardization
@@ -279,10 +293,13 @@ fn standardize_raw_condensed_features(
             const LANES: usize = 8;
 
             // Get initial slice for reading
-            let row_data_slice: &[f32] = feature_row.as_slice().expect("Feature row must be contiguous for read-only operations");
+            let row_data_slice: &[f32] = feature_row
+                .as_slice()
+                .expect("Feature row must be contiguous for read-only operations");
             let num_elements_in_row = row_data_slice.len();
-            
-            if num_elements_in_row == 0 { // Should not happen if num_samples > 0, but good practice
+
+            if num_elements_in_row == 0 {
+                // Should not happen if num_samples > 0, but good practice
                 return;
             }
             let num_simd_chunks = num_elements_in_row / LANES;
@@ -291,7 +308,8 @@ fn standardize_raw_condensed_features(
             let mut simd_sum_f32 = Simd::splat(0.0f32);
             for chunk_idx in 0..num_simd_chunks {
                 let offset = chunk_idx * LANES;
-                let data_chunk = Simd::<f32, LANES>::from_slice(&row_data_slice[offset .. offset + LANES]);
+                let data_chunk =
+                    Simd::<f32, LANES>::from_slice(&row_data_slice[offset..offset + LANES]);
                 simd_sum_f32 += data_chunk;
             }
             let mut total_sum_f32 = simd_sum_f32.reduce_sum();
@@ -302,15 +320,18 @@ fn standardize_raw_condensed_features(
             let mean_val_f32 = mean_val_f64 as f32;
 
             // Get mutable slice for modifications
-            let row_data_mut_slice: &mut [f32] = feature_row.as_slice_mut().expect("Feature row must be contiguous for mutable operations");
+            let row_data_mut_slice: &mut [f32] = feature_row
+                .as_slice_mut()
+                .expect("Feature row must be contiguous for mutable operations");
 
             // --- SIMD Mean Centering ---
             let mean_simd = Simd::splat(mean_val_f32);
             for chunk_idx in 0..num_simd_chunks {
                 let offset = chunk_idx * LANES;
-                let mut data_chunk = Simd::<f32, LANES>::from_slice(&row_data_mut_slice[offset .. offset + LANES]);
+                let mut data_chunk =
+                    Simd::<f32, LANES>::from_slice(&row_data_mut_slice[offset..offset + LANES]);
                 data_chunk -= mean_simd;
-                data_chunk.copy_to_slice(&mut row_data_mut_slice[offset .. offset + LANES]);
+                data_chunk.copy_to_slice(&mut row_data_mut_slice[offset..offset + LANES]);
             }
             for idx in (num_simd_chunks * LANES)..num_elements_in_row {
                 row_data_mut_slice[idx] -= mean_val_f32;
@@ -320,28 +341,31 @@ fn standardize_raw_condensed_features(
             let mut simd_sum_sq_f32 = Simd::splat(0.0f32);
             for chunk_idx in 0..num_simd_chunks {
                 let offset = chunk_idx * LANES;
-                let centered_data_chunk = Simd::<f32, LANES>::from_slice(&row_data_mut_slice[offset .. offset + LANES]);
+                let centered_data_chunk =
+                    Simd::<f32, LANES>::from_slice(&row_data_mut_slice[offset..offset + LANES]);
                 simd_sum_sq_f32 += centered_data_chunk * centered_data_chunk;
             }
             let mut total_sum_sq_f32 = simd_sum_sq_f32.reduce_sum();
             for idx in (num_simd_chunks * LANES)..num_elements_in_row {
                 total_sum_sq_f32 += row_data_mut_slice[idx] * row_data_mut_slice[idx];
             }
-            
+
             // Use (N-1) for sample variance calculation (N is num_elements_in_row here)
-            let variance_f64 = total_sum_sq_f32 as f64 / ((num_elements_in_row as f64 - 1.0).max(1.0)); // Avoid division by zero if num_elements_in_row is 1
+            let variance_f64 =
+                total_sum_sq_f32 as f64 / ((num_elements_in_row as f64 - 1.0).max(1.0)); // Avoid division by zero if num_elements_in_row is 1
             let std_dev_f64 = variance_f64.sqrt();
             let std_dev_f32 = std_dev_f64 as f32;
 
             // --- SIMD Scaling / Fill (operates on row_data_mut_slice) ---
-            if std_dev_f32.abs() > 1e-7 { 
+            if std_dev_f32.abs() > 1e-7 {
                 let inv_std_dev_val = 1.0 / std_dev_f32;
                 let inv_std_dev_simd = Simd::splat(inv_std_dev_val);
                 for chunk_idx in 0..num_simd_chunks {
                     let offset = chunk_idx * LANES;
-                    let mut data_chunk = Simd::<f32, LANES>::from_slice(&row_data_mut_slice[offset .. offset + LANES]);
+                    let mut data_chunk =
+                        Simd::<f32, LANES>::from_slice(&row_data_mut_slice[offset..offset + LANES]);
                     data_chunk *= inv_std_dev_simd;
-                    data_chunk.copy_to_slice(&mut row_data_mut_slice[offset .. offset + LANES]);
+                    data_chunk.copy_to_slice(&mut row_data_mut_slice[offset..offset + LANES]);
                 }
                 for idx in (num_simd_chunks * LANES)..num_elements_in_row {
                     row_data_mut_slice[idx] *= inv_std_dev_val;
@@ -350,30 +374,41 @@ fn standardize_raw_condensed_features(
                 let zero_simd = Simd::<f32, LANES>::splat(0.0f32);
                 for chunk_idx in 0..num_simd_chunks {
                     let offset = chunk_idx * LANES;
-                    zero_simd.copy_to_slice(&mut row_data_mut_slice[offset .. offset + LANES]);
+                    zero_simd.copy_to_slice(&mut row_data_mut_slice[offset..offset + LANES]);
                 }
                 for idx in (num_simd_chunks * LANES)..num_elements_in_row {
                     row_data_mut_slice[idx] = 0.0f32;
                 }
             }
         });
-    
+
     info!("Finished standardizing rows of condensed feature matrix.");
 
-    debug!("Standardized condensed feature matrix (A_eigen_std_star) dimensions: {:?}", condensed_data_matrix.dim());
+    debug!(
+        "Standardized condensed feature matrix (A_eigen_std_star) dimensions: {:?}",
+        condensed_data_matrix.dim()
+    );
     if !condensed_data_matrix.is_empty() {
-        let norm_a_eigen_std_star = condensed_data_matrix.view().mapv(|x| x*x).sum().sqrt();
-        debug!("Standardized condensed feature matrix (A_eigen_std_star) Frobenius norm: {:.4e}", norm_a_eigen_std_star);
+        let norm_a_eigen_std_star = condensed_data_matrix.view().mapv(|x| x * x).sum().sqrt();
+        debug!(
+            "Standardized condensed feature matrix (A_eigen_std_star) Frobenius norm: {:.4e}",
+            norm_a_eigen_std_star
+        );
 
         for row_idx in 0..3.min(condensed_data_matrix.nrows()) {
             let r_view = condensed_data_matrix.row(row_idx);
-            if r_view.len() > 1 { // Variance requires at least 2 elements
+            if r_view.len() > 1 {
+                // Variance requires at least 2 elements
                 let mean_val = r_view.mean().unwrap_or(0.0); // Should be ~0 for standardized data
-                let variance = r_view.mapv(|x| (x - mean_val).powi(2)).mean().unwrap_or(0.0); // Should be ~1 for standardized data
-                // Using debug for variance of standardized matrix as it's a key check of success
-                debug!("Standardized condensed matrix: Row {} mean (post-std): {:.4e}, variance (post-std): {:.4e}", 
+                let variance = r_view
+                    .mapv(|x| (x - mean_val).powi(2))
+                    .mean()
+                    .unwrap_or(0.0); // Should be ~1 for standardized data
+                                     // Using debug for variance of standardized matrix as it's a key check of success
+                debug!("Standardized condensed matrix: Row {} mean (post-std): {:.4e}, variance (post-std): {:.4e}",
                        row_idx, mean_val, variance);
-            } else if r_view.len() == 1 { // Single element in row, variance is undefined or 0. Mean is the element itself.
+            } else if r_view.len() == 1 {
+                // Single element in row, variance is undefined or 0. Mean is the element itself.
                 debug!("Standardized condensed matrix: Row {} mean (post-std): {:.4e}, variance (post-std): N/A (single element in row)",
                        row_idx, r_view.mean().unwrap_or(0.0));
             }
@@ -386,8 +421,9 @@ fn standardize_raw_condensed_features(
             if let Some(dc) = full_diagnostics_collector.as_mut() {
                 dc.c_std_matrix_dims = Some(condensed_data_matrix.dim());
                 if !condensed_data_matrix.is_empty() {
-                    dc.c_std_matrix_fro_norm = Some(compute_frob_norm_f32(&condensed_data_matrix.view()) as f64);
-                    
+                    dc.c_std_matrix_fro_norm =
+                        Some(compute_frob_norm_f32(&condensed_data_matrix.view()) as f64);
+
                     // Sample column means and std devs (they should be ~0 and ~1)
                     let num_cols_to_sample = 10.min(condensed_data_matrix.ncols());
                     if num_cols_to_sample > 0 {
@@ -404,21 +440,25 @@ fn standardize_raw_condensed_features(
                             // Let's assume the spec meant "row means/stds" for C_std (i.e. for each standardized feature).
                             let feature_row = condensed_data_matrix.row(i); // Sample first few features
                             means_sample.push(feature_row.mean().unwrap_or(0.0) as f64); // Should be ~0
-                             let variance = feature_row.mapv(|x| (x - (feature_row.mean().unwrap_or(0.0))).powi(2)).mean().unwrap_or(0.0);
+                            let variance = feature_row
+                                .mapv(|x| (x - (feature_row.mean().unwrap_or(0.0))).powi(2))
+                                .mean()
+                                .unwrap_or(0.0);
                             stds_sample.push(variance.sqrt() as f64); // Should be ~1
                         }
                         dc.c_std_col_means_sample = Some(means_sample); // This is actually row means
                         dc.c_std_col_std_devs_sample = Some(stds_sample); // This is actually row stds
-                         dc.notes.push_str(" Note: c_std_col_means_sample and c_std_col_std_devs_sample actually store ROW means/stds of C_std due to typical interpretation. ");
+                        dc.notes.push_str(" Note: c_std_col_means_sample and c_std_col_std_devs_sample actually store ROW means/stds of C_std due to typical interpretation. ");
                     }
-
                 } else {
                     dc.c_std_matrix_fro_norm = Some(0.0);
                 }
             }
         }
     }
-    Ok(StandardizedCondensedFeatures { data: condensed_data_matrix })
+    Ok(StandardizedCondensedFeatures {
+        data: condensed_data_matrix,
+    })
 }
 
 // --- Helper functions for reordering ndarray structures ---
@@ -514,9 +554,9 @@ pub struct EigenSNPCoreAlgorithmConfig {
     pub global_pca_sketch_oversampling: usize,
     /// Number of power iterations for the global RSVD on the condensed feature matrix.
     pub global_pca_num_power_iterations: usize,
-    
+
     /// Number of additional random dimensions for sketching in the local RSVD stage (L_local = c_p + this).
-    pub local_rsvd_sketch_oversampling: usize, 
+    pub local_rsvd_sketch_oversampling: usize,
     /// Number of power iterations for the local RSVD stage.
     pub local_rsvd_num_power_iterations: usize,
 
@@ -539,7 +579,10 @@ pub struct EigenSNPCoreAlgorithmConfig {
     pub refine_pass_count: usize,
     /// Whether to collect detailed diagnostics during PCA computation.
     pub collect_diagnostics: bool,
-    /// Optional: If set, specifies the `LdBlockListId` (index in the input `ld_block_specifications` list)
+    /// If set, specifies a directory path where the local PC loadings (eigenSNPs)
+    /// for each LD block will be saved as individual TSV files.
+    pub local_pcs_output_dir: Option<String>,
+    /// If set, specifies the `LdBlockListId` (index in the input `ld_block_specifications` list)
     /// for which detailed rSVD step diagnostics should be traced during local basis learning.
     /// This is only active if `collect_diagnostics` is also true and the "enable-eigensnp-diagnostics" feature is enabled.
     #[cfg(feature = "enable-eigensnp-diagnostics")]
@@ -557,12 +600,13 @@ impl Default for EigenSNPCoreAlgorithmConfig {
             target_num_global_pcs: 15,
             global_pca_sketch_oversampling: 10,
             global_pca_num_power_iterations: 2,
-            local_rsvd_sketch_oversampling: 4, 
-            local_rsvd_num_power_iterations: 2, 
+            local_rsvd_sketch_oversampling: 4,
+            local_rsvd_num_power_iterations: 2,
             random_seed: 2025,
             snp_processing_strip_size: 2000, // Default
-            refine_pass_count: 1, // Default to 1 refinement pass
+            refine_pass_count: 1,            // Default to 1 refinement pass
             collect_diagnostics: false,
+            local_pcs_output_dir: None,
             #[cfg(feature = "enable-eigensnp-diagnostics")]
             diagnostic_block_list_id_to_trace: None,
         }
@@ -591,8 +635,12 @@ impl EigenSNPCoreAlgorithm {
             if self.config.collect_diagnostics {
                 let mut main_diag_collector = FullPcaRunDetailedDiagnostics::default();
                 // Record config summary in notes
-                main_diag_collector.notes.push_str(&format!("EigenSNPCoreAlgorithmConfig: {:?}. ", self.config));
-                main_diag_collector.notes.push_str("EigenSNP PCA run started. ");
+                main_diag_collector
+                    .notes
+                    .push_str(&format!("EigenSNPCoreAlgorithmConfig: {:?}. ", self.config));
+                main_diag_collector
+                    .notes
+                    .push_str("EigenSNP PCA run started. ");
                 diagnostics_collector = Some(main_diag_collector);
             }
         }
@@ -605,10 +653,15 @@ impl EigenSNPCoreAlgorithm {
         let num_total_pca_snps = genotype_data.num_pca_snps();
 
         // Determine subset sample IDs based on config
-        let desired_subset_sample_count = (self.config.subset_factor_for_local_basis_learning * num_total_qc_samples as f64).round() as usize;
-        let clamped_min_subset_sample_count = desired_subset_sample_count.max(self.config.min_subset_size_for_local_basis_learning);
+        let desired_subset_sample_count = (self.config.subset_factor_for_local_basis_learning
+            * num_total_qc_samples as f64)
+            .round() as usize;
+        let clamped_min_subset_sample_count =
+            desired_subset_sample_count.max(self.config.min_subset_size_for_local_basis_learning);
         // Make actual_subset_sample_count mutable here for potential override
-        let mut actual_subset_sample_count = clamped_min_subset_sample_count.min(self.config.max_subset_size_for_local_basis_learning).min(num_total_qc_samples);
+        let mut actual_subset_sample_count = clamped_min_subset_sample_count
+            .min(self.config.max_subset_size_for_local_basis_learning)
+            .min(num_total_qc_samples);
 
         info!(
             "Starting EigenSNP PCA. Target PCs={}, Total Samples={}, Subset Samples (N_s, initial)={}, Num LD Blocks={}",
@@ -621,10 +674,18 @@ impl EigenSNPCoreAlgorithm {
 
         // Input Validations
         if self.config.target_num_global_pcs == 0 {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Target number of global PCs must be greater than 0.").into());
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "Target number of global PCs must be greater than 0.",
+            )
+            .into());
         }
         if num_total_pca_snps > 0 && ld_block_specifications.is_empty() {
-            return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "LD block specifications cannot be empty if PCA SNPs are present.").into());
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                "LD block specifications cannot be empty if PCA SNPs are present.",
+            )
+            .into());
         }
         if num_total_qc_samples == 0 {
             warn!("Genotype data has zero QC samples. Returning empty PCA output.");
@@ -658,13 +719,12 @@ impl EigenSNPCoreAlgorithm {
         }
 
         let subset_sample_ids_selected: Vec<QcSampleId>;
-        let is_diagnostic_target_test = 
-            num_total_qc_samples == 200 && 
-            (num_total_pca_snps >= 950 && num_total_pca_snps <= 1050); // Approximate SNP count
+        let is_diagnostic_target_test = num_total_qc_samples == 200
+            && (num_total_pca_snps >= 950 && num_total_pca_snps <= 1050); // Approximate SNP count
 
         if is_diagnostic_target_test {
             log::warn!(
-                "DIAGNOSTIC MODE ACTIVE: Using ALL {} samples for local basis learning (N_s = N) for test_pc_correlation_structured_1000snps_200samples_5truepcs scenario. Original N_s was {}.", 
+                "DIAGNOSTIC MODE ACTIVE: Using ALL {} samples for local basis learning (N_s = N) for test_pc_correlation_structured_1000snps_200samples_5truepcs scenario. Original N_s was {}.",
                 num_total_qc_samples, actual_subset_sample_count
             );
             actual_subset_sample_count = num_total_qc_samples; // Override N_s
@@ -678,28 +738,119 @@ impl EigenSNPCoreAlgorithm {
             // Original logic for selecting subset_sample_ids_selected
             if actual_subset_sample_count > 0 {
                 let mut rng_subset_selection = ChaCha8Rng::seed_from_u64(self.config.random_seed);
-                let subset_indices: Vec<usize> = rand::seq::index::sample(&mut rng_subset_selection, num_total_qc_samples, actual_subset_sample_count).into_vec();
+                let subset_indices: Vec<usize> = rand::seq::index::sample(
+                    &mut rng_subset_selection,
+                    num_total_qc_samples,
+                    actual_subset_sample_count,
+                )
+                .into_vec();
                 subset_sample_ids_selected = subset_indices.into_iter().map(QcSampleId).collect();
             } else {
-                 if num_total_qc_samples > 0 && ld_block_specifications.iter().any(|b| b.num_snps_in_block() > 0) {
-                     log::warn!("Calculated N_s is 0 (and not in diagnostic override), but total samples > 0 and blocks have SNPs. This situation is problematic for learning local bases.");
-                     return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Subset size (N_s) for local basis learning is 0, but samples and SNP blocks are present.").into());
-                 }
-                 subset_sample_ids_selected = Vec::new();
+                if num_total_qc_samples > 0
+                    && ld_block_specifications
+                        .iter()
+                        .any(|b| b.num_snps_in_block() > 0)
+                {
+                    log::warn!("Calculated N_s is 0 (and not in diagnostic override), but total samples > 0 and blocks have SNPs. This situation is problematic for learning local bases.");
+                    return Err(std::io::Error::new(std::io::ErrorKind::InvalidInput, "Subset size (N_s) for local basis learning is 0, but samples and SNP blocks are present.").into());
+                }
+                subset_sample_ids_selected = Vec::new();
             }
         }
 
+        // Create the output directory for local PCs ONCE at the beginning if specified.
+        if let Some(dir_str) = self.config.local_pcs_output_dir.as_ref() {
+            std::fs::create_dir_all(dir_str).map_err(|e| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!(
+                        "Failed to create local PCs output directory '{}': {}",
+                        dir_str, e
+                    ),
+                )) as ThreadSafeStdError
+            })?;
+        }
+
         let local_bases_learning_start_time = std::time::Instant::now();
-        let all_block_local_bases = self.learn_all_ld_block_local_bases(
-            genotype_data,
-            ld_block_specifications,
-            &subset_sample_ids_selected,
-            #[cfg(feature = "enable-eigensnp-diagnostics")]
-            diagnostics_collector.as_mut().map(|dc| &mut dc.per_block_diagnostics),
-            #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-            None,
-        )?;
-        info!("Learned local SNP bases in {:?}", local_bases_learning_start_time.elapsed());
+
+        // This `if/else` block dispatches to one of two specialized (monomorphized)
+        // versions of `learn_all_ld_block_local_bases`. This ensures that when
+        // `local_pcs_output_dir` is not set, the no-op closure is used, and the
+        // compiler completely eliminates any overhead, achieving a true zero-cost abstraction.
+        // The alternative, using dynamic dispatch (`Box<dyn FnMut>`), would avoid
+        // duplicating the function call but would introduce a runtime vtable lookup cost.
+        // For this performance-critical path, static dispatch is the correct choice.
+        let all_block_local_bases = if let Some(dir_str) = self.config.local_pcs_output_dir.as_ref()
+        {
+            // --- BRANCH 1: Define and pass the file-writing closure. ---
+            let output_dir = std::path::PathBuf::from(dir_str);
+            self.learn_all_ld_block_local_bases(
+                genotype_data,
+                ld_block_specifications,
+                &subset_sample_ids_selected,
+                // This closure captures the `output_dir` and performs the file I/O.
+                |local_pcs, block_list_id| {
+                    if local_pcs.is_empty() {
+                        return Ok(());
+                    }
+
+                    let filename =
+                        output_dir.join(format!("block_{}.local_loadings.tsv", block_list_id.0));
+                    let file =
+                        std::fs::File::create(&filename).map_err(|e| -> ThreadSafeStdError {
+                            Box::new(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!(
+                                    "Failed to create local PC file '{}': {}",
+                                    filename.display(),
+                                    e
+                                ),
+                            ))
+                        })?;
+
+                    let mut writer = std::io::BufWriter::new(file);
+                    use std::io::Write; // Import the Write trait for writeln!
+
+                    // Use a standard `for` loop for robust, fallible I/O operations.
+                    for row in local_pcs.rows() {
+                        let row_str = row
+                            .iter()
+                            .map(|&val| val.to_string())
+                            .collect::<Vec<String>>()
+                            .join("\t");
+                        // The `?` operator will correctly propagate any I/O error,
+                        // causing the closure to return an `Err` immediately.
+                        writeln!(writer, "{}", row_str)?;
+                    }
+                    Ok(())
+                },
+                #[cfg(feature = "enable-eigensnp-diagnostics")]
+                diagnostics_collector
+                    .as_mut()
+                    .map(|dc| &mut dc.per_block_diagnostics),
+                #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+                None,
+            )?
+        } else {
+            // --- BRANCH 2: Define and pass the zero-cost, no-op closure. ---
+            self.learn_all_ld_block_local_bases(
+                genotype_data,
+                ld_block_specifications,
+                &subset_sample_ids_selected,
+                // This closure does nothing and will be completely optimized away by the compiler.
+                |_, _| Ok(()),
+                #[cfg(feature = "enable-eigensnp-diagnostics")]
+                diagnostics_collector
+                    .as_mut()
+                    .map(|dc| &mut dc.per_block_diagnostics),
+                #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+                None,
+            )?
+        };
+        info!(
+            "Learned local SNP bases in {:?}",
+            local_bases_learning_start_time.elapsed()
+        );
 
         let condensed_matrix_construction_start_time = std::time::Instant::now();
         let raw_condensed_feature_matrix = self.project_all_samples_onto_local_bases(
@@ -712,36 +863,47 @@ impl EigenSNPCoreAlgorithm {
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
             None,
         )?;
-        info!("Constructed raw condensed feature matrix in {:?}", condensed_matrix_construction_start_time.elapsed());
+        info!(
+            "Constructed raw condensed feature matrix in {:?}",
+            condensed_matrix_construction_start_time.elapsed()
+        );
 
         let condensed_matrix_standardization_start_time = std::time::Instant::now();
-        let standardized_condensed_feature_matrix =
-            standardize_raw_condensed_features(
-                raw_condensed_feature_matrix,
-                self.config.collect_diagnostics,
-                #[cfg(feature = "enable-eigensnp-diagnostics")]
-                diagnostics_collector.as_mut(),
-                #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-                None,
-            )?; 
-        info!("Standardized condensed feature matrix in {:?}", condensed_matrix_standardization_start_time.elapsed());
-
-        let initial_global_pca_start_time = std::time::Instant::now();
-        let mut current_sample_scores = self.compute_pca_on_standardized_condensed_features_via_rsvd(
-            &standardized_condensed_feature_matrix,
+        let standardized_condensed_feature_matrix = standardize_raw_condensed_features(
+            raw_condensed_feature_matrix,
+            self.config.collect_diagnostics,
             #[cfg(feature = "enable-eigensnp-diagnostics")]
-            diagnostics_collector.as_mut().and_then(|dc| dc.global_pca_diag.as_mut().map(|gpd_box| gpd_box.as_mut())),
+            diagnostics_collector.as_mut(),
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
             None,
         )?;
-        info!("Computed initial global PCA on condensed features in {:?}", initial_global_pca_start_time.elapsed());
+        info!(
+            "Standardized condensed feature matrix in {:?}",
+            condensed_matrix_standardization_start_time.elapsed()
+        );
+
+        let initial_global_pca_start_time = std::time::Instant::now();
+        let mut current_sample_scores = self
+            .compute_pca_on_standardized_condensed_features_via_rsvd(
+                &standardized_condensed_feature_matrix,
+                #[cfg(feature = "enable-eigensnp-diagnostics")]
+                diagnostics_collector
+                    .as_mut()
+                    .and_then(|dc| dc.global_pca_diag.as_mut().map(|gpd_box| gpd_box.as_mut())),
+                #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+                None,
+            )?;
+        info!(
+            "Computed initial global PCA on condensed features in {:?}",
+            initial_global_pca_start_time.elapsed()
+        );
 
         let mut num_principal_components_computed_final = current_sample_scores.scores.ncols();
         if num_principal_components_computed_final == 0 {
             warn!("Initial PCA on condensed features yielded 0 components. Returning empty PCA output.");
             let output = EigenSNPCoreOutput {
-                final_snp_principal_component_loadings: Array2::zeros((num_total_pca_snps,0)),
-                final_sample_principal_component_scores: Array2::zeros((num_total_qc_samples,0)),
+                final_snp_principal_component_loadings: Array2::zeros((num_total_pca_snps, 0)),
+                final_sample_principal_component_scores: Array2::zeros((num_total_qc_samples, 0)),
                 final_principal_component_eigenvalues: Array1::zeros(0),
                 num_qc_samples_used: num_total_qc_samples,
                 num_pca_snps_used: num_total_pca_snps,
@@ -752,108 +914,123 @@ impl EigenSNPCoreAlgorithm {
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
             return Ok((output, ())); // Correct
         }
-        
+
         let mut final_sorted_snp_loadings: Array2<f32> = Array2::zeros((num_total_pca_snps, 0));
         let mut final_sorted_eigenvalues: Array1<f64> = Array1::zeros(0);
 
-
-
-     if self.config.refine_pass_count == 0 {
-         warn!(
+        if self.config.refine_pass_count == 0 {
+            warn!(
              "EigenSNP refine_pass_count is 0. Skipping refinement loop. Output will reflect PCA of derived local eigenSNP features only. SNP loadings and SNP-based eigenvalues will be empty/zero."
          );
-         // `num_principal_components_computed_final` is already set from the initial condensed PCA.
-         // `final_sorted_snp_loadings` and `final_sorted_eigenvalues` remain their initial empty/zero states.
-         // `current_sample_scores` holds the scores from the condensed PCA, which will be used.
-     } else {
-         // Refinement Loop
-         // Pass 1 uses initial_sample_pc_scores. Subsequent passes use scores from the previous iteration.
-         for pass_num in 1..=self.config.refine_pass_count { // Allows zero.
-             
-             #[cfg(feature = "enable-eigensnp-diagnostics")]
-             let mut current_sr_pass_detail_option: Option<SrPassDetail> = None;
-             #[cfg(feature = "enable-eigensnp-diagnostics")]
-             {
-                 if self.config.collect_diagnostics && diagnostics_collector.is_some() {
-                     let mut detail = SrPassDetail::default();
-                     detail.pass_num = pass_num;
-                     current_sr_pass_detail_option = Some(detail);
-                 }
-             }
+            // `num_principal_components_computed_final` is already set from the initial condensed PCA.
+            // `final_sorted_snp_loadings` and `final_sorted_eigenvalues` remain their initial empty/zero states.
+            // `current_sample_scores` holds the scores from the condensed PCA, which will be used.
+        } else {
+            // Refinement Loop
+            // Pass 1 uses initial_sample_pc_scores. Subsequent passes use scores from the previous iteration.
+            for pass_num in 1..=self.config.refine_pass_count {
+                // Allows zero.
 
-             debug!(
-                 "Starting Refinement Pass {} with {} PCs from previous step.", 
-                 pass_num, 
-                 current_sample_scores.scores.ncols()
-             );
+                #[cfg(feature = "enable-eigensnp-diagnostics")]
+                let mut current_sr_pass_detail_option: Option<SrPassDetail> = None;
+                #[cfg(feature = "enable-eigensnp-diagnostics")]
+                {
+                    if self.config.collect_diagnostics && diagnostics_collector.is_some() {
+                        let mut detail = SrPassDetail::default();
+                        detail.pass_num = pass_num;
+                        current_sr_pass_detail_option = Some(detail);
+                    }
+                }
 
-             if current_sample_scores.scores.ncols() == 0 {
-                 warn!("Refinement Pass {}: Input scores have 0 components. Cannot proceed with refinement.", pass_num);
-                 if pass_num == 1 { 
-                      final_sorted_snp_loadings = Array2::zeros((num_total_pca_snps,0));
-                 } 
-                 num_principal_components_computed_final = 0; 
-                 break; 
-             }
+                debug!(
+                    "Starting Refinement Pass {} with {} PCs from previous step.",
+                    pass_num,
+                    current_sample_scores.scores.ncols()
+                );
 
-             let loadings_refinement_start_time = std::time::Instant::now();
-             let v_qr_snp_loadings = self.compute_refined_snp_loadings(
-                 genotype_data,
-                 &current_sample_scores,
-                 #[cfg(feature = "enable-eigensnp-diagnostics")]
-                 current_sr_pass_detail_option.as_mut(),
-                 #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-                 None,
-             )?;
-             info!("Pass {}: Computed QR-based SNP loadings (intermediate V_qr) in {:?}", pass_num, loadings_refinement_start_time.elapsed());
-             
-             if v_qr_snp_loadings.ncols() == 0 {
-                 warn!("Pass {}: Intermediate QR-based SNP loadings (V_qr) resulted in 0 components. Ending refinement.", pass_num);
-                 if pass_num == 1 { 
-                     final_sorted_snp_loadings = v_qr_snp_loadings; 
-                 } 
-                 num_principal_components_computed_final = 0;
-                 break; 
-             }
+                if current_sample_scores.scores.ncols() == 0 {
+                    warn!("Refinement Pass {}: Input scores have 0 components. Cannot proceed with refinement.", pass_num);
+                    if pass_num == 1 {
+                        final_sorted_snp_loadings = Array2::zeros((num_total_pca_snps, 0));
+                    }
+                    num_principal_components_computed_final = 0;
+                    break;
+                }
 
-             let final_outputs_computation_start_time = std::time::Instant::now();
-             let (
-                 sorted_scores_this_pass,
-                 sorted_eigenvalues_this_pass,
-                 sorted_loadings_this_pass
-             ) = self.compute_rotated_final_outputs(
-                 genotype_data,
-                 &v_qr_snp_loadings.view(),
-                 num_total_qc_samples,
-                 #[cfg(feature = "enable-eigensnp-diagnostics")]
-                 current_sr_pass_detail_option.as_mut(),
-                 #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-                 None,
-             )?;
-             info!("Pass {}: Computed final rotated scores, eigenvalues, and loadings in {:?}", pass_num, final_outputs_computation_start_time.elapsed());
+                let loadings_refinement_start_time = std::time::Instant::now();
+                let v_qr_snp_loadings = self.compute_refined_snp_loadings(
+                    genotype_data,
+                    &current_sample_scores,
+                    #[cfg(feature = "enable-eigensnp-diagnostics")]
+                    current_sr_pass_detail_option.as_mut(),
+                    #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+                    None,
+                )?;
+                info!(
+                    "Pass {}: Computed QR-based SNP loadings (intermediate V_qr) in {:?}",
+                    pass_num,
+                    loadings_refinement_start_time.elapsed()
+                );
 
-             current_sample_scores = InitialSamplePcScores { scores: sorted_scores_this_pass.clone() }; 
-             
-             final_sorted_snp_loadings = sorted_loadings_this_pass;
-             final_sorted_eigenvalues = sorted_eigenvalues_this_pass;
-             num_principal_components_computed_final = final_sorted_snp_loadings.ncols();
+                if v_qr_snp_loadings.ncols() == 0 {
+                    warn!("Pass {}: Intermediate QR-based SNP loadings (V_qr) resulted in 0 components. Ending refinement.", pass_num);
+                    if pass_num == 1 {
+                        final_sorted_snp_loadings = v_qr_snp_loadings;
+                    }
+                    num_principal_components_computed_final = 0;
+                    break;
+                }
 
-             if num_principal_components_computed_final == 0 {
-                 warn!("Pass {}: Refinement resulted in 0 final components. Ending refinement.", pass_num);
-                 break; 
-             }
+                let final_outputs_computation_start_time = std::time::Instant::now();
+                let (
+                    sorted_scores_this_pass,
+                    sorted_eigenvalues_this_pass,
+                    sorted_loadings_this_pass,
+                ) = self.compute_rotated_final_outputs(
+                    genotype_data,
+                    &v_qr_snp_loadings.view(),
+                    num_total_qc_samples,
+                    #[cfg(feature = "enable-eigensnp-diagnostics")]
+                    current_sr_pass_detail_option.as_mut(),
+                    #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+                    None,
+                )?;
+                info!(
+                    "Pass {}: Computed final rotated scores, eigenvalues, and loadings in {:?}",
+                    pass_num,
+                    final_outputs_computation_start_time.elapsed()
+                );
 
-             #[cfg(feature = "enable-eigensnp-diagnostics")]
-             {
-                 if let (Some(dc), Some(sr_detail)) = (diagnostics_collector.as_mut(), current_sr_pass_detail_option) {
-                     if self.config.collect_diagnostics {
-                         dc.sr_pass_details.push(sr_detail);
-                     }
-                 }
-             }
-         }
-         // End of Refinement Loop
-     }        
+                current_sample_scores = InitialSamplePcScores {
+                    scores: sorted_scores_this_pass.clone(),
+                };
+
+                final_sorted_snp_loadings = sorted_loadings_this_pass;
+                final_sorted_eigenvalues = sorted_eigenvalues_this_pass;
+                num_principal_components_computed_final = final_sorted_snp_loadings.ncols();
+
+                if num_principal_components_computed_final == 0 {
+                    warn!(
+                        "Pass {}: Refinement resulted in 0 final components. Ending refinement.",
+                        pass_num
+                    );
+                    break;
+                }
+
+                #[cfg(feature = "enable-eigensnp-diagnostics")]
+                {
+                    if let (Some(dc), Some(sr_detail)) = (
+                        diagnostics_collector.as_mut(),
+                        current_sr_pass_detail_option,
+                    ) {
+                        if self.config.collect_diagnostics {
+                            dc.sr_pass_details.push(sr_detail);
+                        }
+                    }
+                }
+            }
+            // End of Refinement Loop
+        }
 
         // current_sample_scores now holds the sample scores from the last completed refinement pass.
         // final_sorted_snp_loadings and final_sorted_eigenvalues also hold results from the last completed pass.
@@ -890,18 +1067,27 @@ impl EigenSNPCoreAlgorithm {
             // This also matches PcaOutputWithDiagnostics where the second element is ()
             Ok((output_final, ()))
         }
-}
+    }
 
     // fn learn_all_ld_block_local_bases... (the trait was moved from here)
 
-    fn learn_all_ld_block_local_bases<G: PcaReadyGenotypeAccessor>(
+    fn learn_all_ld_block_local_bases<G, F>(
         &self,
         genotype_data: &G,
         ld_block_specs: &[LdBlockSpecification],
         subset_sample_ids: &[QcSampleId],
-        #[cfg(feature = "enable-eigensnp-diagnostics")] mut diagnostics_collector: Option<&mut Vec<crate::diagnostics::PerBlockLocalBasisDiagnostics>>, // 
-        #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector_param: Option<()>, // Renamed to avoid conflict
-    ) -> Result<Vec<LocalBasisWithDiagnostics>, ThreadSafeStdError> {
+        on_local_pcs_generated: F,
+        #[cfg(feature = "enable-eigensnp-diagnostics")] mut diagnostics_collector: Option<
+            &mut Vec<crate::diagnostics::PerBlockLocalBasisDiagnostics>,
+        >,
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector_param: Option<
+            (),
+        >,
+    ) -> Result<Vec<LocalBasisWithDiagnostics>, ThreadSafeStdError>
+    where
+        G: PcaReadyGenotypeAccessor,
+        F: Fn(&ArrayView2<f32>, LdBlockListId) -> Result<(), ThreadSafeStdError> + Send + Sync,
+    {
         info!(
             "Learning local eigenSNP bases for {} LD blocks using N_subset = {} samples.",
             ld_block_specs.len(),
@@ -954,8 +1140,8 @@ impl EigenSNPCoreAlgorithm {
                             &block_spec.pca_snp_ids_in_block,
                             subset_sample_ids,
                         ).map_err(|e_accessor| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to get standardized SNP/sample block for block ID {:?} ({}): {}", block_list_id, block_tag, e_accessor))) as ThreadSafeStdError)?;
-                    
-                    debug!("Block {}: X_sp (subset genotype block) dimensions: {:?}", 
+
+                    debug!("Block {}: X_sp (subset genotype block) dimensions: {:?}",
                            block_tag, genotype_block_for_subset_samples.dim());
 
                     #[cfg(feature = "enable-eigensnp-diagnostics")]
@@ -979,7 +1165,7 @@ impl EigenSNPCoreAlgorithm {
 
                     let actual_num_snps_in_block = genotype_block_for_subset_samples.nrows();
                     let actual_num_subset_samples = genotype_block_for_subset_samples.ncols();
-                    
+
                     let num_components_to_extract = self.config.components_per_ld_block
                         .min(actual_num_snps_in_block)
                         .min(if actual_num_subset_samples > 0 { actual_num_subset_samples } else { 0 });
@@ -988,13 +1174,13 @@ impl EigenSNPCoreAlgorithm {
                     // It determines the content of 'basis_vectors_for_block'
                     if num_components_to_extract == 0 {
                         debug!(
-                            "Block {}: Num components to extract is 0 (SNPs_in_block={}, N_subset={}, Configured_cp={}), creating empty basis.", 
+                            "Block {}: Num components to extract is 0 (SNPs_in_block={}, N_subset={}, Configured_cp={}), creating empty basis.",
                             block_tag,
-                            actual_num_snps_in_block, 
+                            actual_num_snps_in_block,
                             actual_num_subset_samples,
                             self.config.components_per_ld_block
                         );
-                        
+
                         #[cfg(feature = "enable-eigensnp-diagnostics")]
                         {
                             // per_block_diag_entry_for_map is already defined and mutable.
@@ -1039,7 +1225,7 @@ impl EigenSNPCoreAlgorithm {
                             if diagnostics_collector.is_some() && self.config.collect_diagnostics {
                                 let (r_up, c_up) = local_basis_vectors_f32.dim();
                                 // Update the u_p_dims field of the already defined per_block_diag_entry_for_map
-                                per_block_diag_entry_for_map.u_p_dims = Some((r_up, c_up)); 
+                                per_block_diag_entry_for_map.u_p_dims = Some((r_up, c_up));
                                 if !local_basis_vectors_f32.is_empty() {
                                     per_block_diag_entry_for_map.u_p_fro_norm = Some(compute_frob_norm_f32(&local_basis_vectors_f32.view()) as f64);
                                     per_block_diag_entry_for_map.u_p_orthogonality_error = compute_orthogonality_error_f32(&local_basis_vectors_f32.view());
@@ -1055,7 +1241,7 @@ impl EigenSNPCoreAlgorithm {
                                                 if k_to_compare > 0 {
                                                     let u_p_f32_view = local_basis_vectors_f32.slice_axis(Axis(1), ndarray::Slice::from(0..k_to_compare));
                                                     let u_true_f64_view = u_true_f64.slice_axis(Axis(1), ndarray::Slice::from(0..k_to_compare));
-                                                    per_block_diag_entry_for_map.u_correlation_vs_f64_truth = 
+                                                    per_block_diag_entry_for_map.u_correlation_vs_f64_truth =
                                                         compute_matrix_column_correlations_abs(&u_p_f32_view, &u_true_f64_view.view());
                                                 }
                                             } else { per_block_diag_entry_for_map.notes.push_str(" ;f64 SVD U_true was None"); }
@@ -1068,11 +1254,16 @@ impl EigenSNPCoreAlgorithm {
                         local_basis_vectors_f32
                     }
                 }; // End of basis_vectors_for_block assignment
-                
+
                 let basis_result = PerBlockLocalSnpBasis {
                     block_list_id,
                     basis_vectors: basis_vectors_for_block,
                 };
+
+                // Invoke the provided closure to consume the generated local PCs.
+                // This call is monomorphized by the compiler to be either a file-writing
+                // operation or a true no-op, achieving a zero-cost abstraction.
+                on_local_pcs_generated(&basis_result.basis_vectors.view(), block_list_id)?;
 
                 // Now, per_block_diag_entry_for_map is guaranteed to be in scope.
                 #[cfg(feature = "enable-eigensnp-diagnostics")]
@@ -1083,12 +1274,14 @@ impl EigenSNPCoreAlgorithm {
                 Ok((basis_result, diag_to_return))
             })
             .collect();
-        
+
         // Separate results and diagnostics
         let mut final_results_tuples = Vec::with_capacity(local_bases_results.len());
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
-        let mut collected_diagnostics_entries: Vec<crate::diagnostics::PerBlockLocalBasisDiagnostics> = Vec::new();
+        let mut collected_diagnostics_entries: Vec<
+            crate::diagnostics::PerBlockLocalBasisDiagnostics,
+        > = Vec::new();
 
         for result_item_tuple in local_bases_results {
             // Each item in local_bases_results is Result<(PerBlockLocalSnpBasis, ActualDiagType), ThreadSafeStdError>>
@@ -1102,7 +1295,8 @@ impl EigenSNPCoreAlgorithm {
                 // The diagnostics_collector.is_some() check is also good to ensure it's not None
                 // if self.config.collect_diagnostics was true but initialization somehow failed (though less likely).
                 if self.config.collect_diagnostics && diagnostics_collector.is_some() {
-                    collected_diagnostics_entries.push(diag_entry_for_this_block.clone()); // Clone and store
+                    collected_diagnostics_entries.push(diag_entry_for_this_block.clone());
+                    // Clone and store
                 }
             }
             // If diagnostics are not enabled, diag_entry_for_this_block is (), which is Copy.
@@ -1136,9 +1330,11 @@ impl EigenSNPCoreAlgorithm {
         &self,
         genotype_data: &G,
         ld_block_specs: &[LdBlockSpecification],
-        all_local_bases: &[LocalBasisWithDiagnostics], 
+        all_local_bases: &[LocalBasisWithDiagnostics],
         num_total_qc_samples: usize,
-        #[cfg(feature = "enable-eigensnp-diagnostics")] mut full_diagnostics_collector: Option<&mut crate::diagnostics::FullPcaRunDetailedDiagnostics>,
+        #[cfg(feature = "enable-eigensnp-diagnostics")] mut full_diagnostics_collector: Option<
+            &mut crate::diagnostics::FullPcaRunDetailedDiagnostics,
+        >,
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _full_diagnostics_collector: Option<()>,
     ) -> Result<RawCondensedFeatures, ThreadSafeStdError> {
         assert_eq!(
@@ -1153,7 +1349,10 @@ impl EigenSNPCoreAlgorithm {
             num_total_qc_samples
         );
 
-        let total_num_condensed_features: usize = all_local_bases.iter().map(|basis| basis.0.basis_vectors.ncols()).sum();
+        let total_num_condensed_features: usize = all_local_bases
+            .iter()
+            .map(|basis| basis.0.basis_vectors.ncols())
+            .sum();
 
         if total_num_condensed_features == 0 {
             info!("Total condensed features is 0. Returning empty RawCondensedFeatures.");
@@ -1161,44 +1360,67 @@ impl EigenSNPCoreAlgorithm {
                 data: Array2::<f32>::zeros((0, num_total_qc_samples)),
             });
         }
-        debug!("Total number of condensed features (rows in A_eigen) = {}", total_num_condensed_features);
+        debug!(
+            "Total number of condensed features (rows in A_eigen) = {}",
+            total_num_condensed_features
+        );
 
         let mut raw_condensed_data_matrix =
             Array2::<f32>::zeros((total_num_condensed_features, num_total_qc_samples));
         let mut current_condensed_feature_row_offset = 0;
 
-        let all_qc_sample_ids: Vec<QcSampleId> = (0..num_total_qc_samples).map(QcSampleId).collect();
+        let all_qc_sample_ids: Vec<QcSampleId> =
+            (0..num_total_qc_samples).map(QcSampleId).collect();
 
         for block_idx in 0..ld_block_specs.len() {
             let block_spec = &ld_block_specs[block_idx];
             let block_tag = &block_spec.user_defined_block_tag;
-        let (local_basis_data, _) = &all_local_bases[block_idx]; // Destructure the tuple
-            
-        let local_snp_basis_vectors = &local_basis_data.basis_vectors;
+            let (local_basis_data, _) = &all_local_bases[block_idx]; // Destructure the tuple
+
+            let local_snp_basis_vectors = &local_basis_data.basis_vectors;
             let num_components_this_block = local_snp_basis_vectors.ncols();
 
             if block_spec.num_snps_in_block() == 0 || num_components_this_block == 0 {
-                trace!("Project Samples: Skipping block {} for projection: num_snps={} or num_local_components=0.", 
+                trace!("Project Samples: Skipping block {} for projection: num_snps={} or num_local_components=0.",
                        block_tag, block_spec.num_snps_in_block());
                 continue;
             }
-            
+
             let genotype_data_for_block_all_samples = genotype_data.get_standardized_snp_sample_block(
                 &block_spec.pca_snp_ids_in_block,
                 &all_qc_sample_ids,
             ).map_err(|e_accessor| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to get standardized SNP/sample block during projection for block '{}': {}", block_tag, e_accessor))) as ThreadSafeStdError)?;
-            
-            // projected_scores_for_block = Sp_star = Up_star.T * Xp (cp x N)
-            let projected_scores_for_block = Self::dot_product_at_b_mixed_precision(&local_snp_basis_vectors.view(), &genotype_data_for_block_all_samples.view())?;
 
-            debug!("Block {}: Projected scores (Sp_star) dimensions: {:?}", 
-                   block_tag, projected_scores_for_block.dim());
+            // projected_scores_for_block = Sp_star = Up_star.T * Xp (cp x N)
+            let projected_scores_for_block = Self::dot_product_at_b_mixed_precision(
+                &local_snp_basis_vectors.view(),
+                &genotype_data_for_block_all_samples.view(),
+            )?;
+
+            debug!(
+                "Block {}: Projected scores (Sp_star) dimensions: {:?}",
+                block_tag,
+                projected_scores_for_block.dim()
+            );
             if !projected_scores_for_block.is_empty() {
-                let norm_sp_star = projected_scores_for_block.view().mapv(|x| x*x).sum().sqrt();
-                trace!("Block {}: Projected scores (Sp_star) Frobenius norm: {:.4e}", 
-                       block_tag, norm_sp_star);
-                trace!("Block {}: Projected scores (Sp_star) sample: {:?}", 
-                       block_tag, projected_scores_for_block.slice(s![0..3.min(projected_scores_for_block.nrows()), 0..3.min(projected_scores_for_block.ncols())]));
+                let norm_sp_star = projected_scores_for_block
+                    .view()
+                    .mapv(|x| x * x)
+                    .sum()
+                    .sqrt();
+                trace!(
+                    "Block {}: Projected scores (Sp_star) Frobenius norm: {:.4e}",
+                    block_tag,
+                    norm_sp_star
+                );
+                trace!(
+                    "Block {}: Projected scores (Sp_star) sample: {:?}",
+                    block_tag,
+                    projected_scores_for_block.slice(s![
+                        0..3.min(projected_scores_for_block.nrows()),
+                        0..3.min(projected_scores_for_block.ncols())
+                    ])
+                );
             }
 
             raw_condensed_data_matrix
@@ -1211,24 +1433,48 @@ impl EigenSNPCoreAlgorithm {
 
             current_condensed_feature_row_offset += num_components_this_block;
         }
-        
-        debug!("Raw condensed feature matrix (A_eigen_star) dimensions: {:?}", raw_condensed_data_matrix.dim());
+
+        debug!(
+            "Raw condensed feature matrix (A_eigen_star) dimensions: {:?}",
+            raw_condensed_data_matrix.dim()
+        );
         if !raw_condensed_data_matrix.is_empty() {
-            let norm_a_eigen_star = raw_condensed_data_matrix.view().mapv(|x| x*x).sum().sqrt();
-            debug!("Raw condensed feature matrix (A_eigen_star) Frobenius norm: {:.4e}", norm_a_eigen_star);
+            let norm_a_eigen_star = raw_condensed_data_matrix
+                .view()
+                .mapv(|x| x * x)
+                .sum()
+                .sqrt();
+            debug!(
+                "Raw condensed feature matrix (A_eigen_star) Frobenius norm: {:.4e}",
+                norm_a_eigen_star
+            );
 
             for row_idx in 0..3.min(raw_condensed_data_matrix.nrows()) {
                 let r_view = raw_condensed_data_matrix.row(row_idx);
-                if r_view.len() > 1 { // Variance requires at least 2 elements
+                if r_view.len() > 1 {
+                    // Variance requires at least 2 elements
                     let mean_val = r_view.mean().unwrap_or(0.0);
-                    let variance = r_view.mapv(|x| (x - mean_val).powi(2)).mean().unwrap_or(0.0);
-                    trace!("Raw condensed matrix: Row {} variance (pre-std): {:.4e}", row_idx, variance);
+                    let variance = r_view
+                        .mapv(|x| (x - mean_val).powi(2))
+                        .mean()
+                        .unwrap_or(0.0);
+                    trace!(
+                        "Raw condensed matrix: Row {} variance (pre-std): {:.4e}",
+                        row_idx,
+                        variance
+                    );
                 } else if r_view.len() == 1 {
-                     trace!("Raw condensed matrix: Row {} variance (pre-std): N/A (single element)", row_idx);
+                    trace!(
+                        "Raw condensed matrix: Row {} variance (pre-std): N/A (single element)",
+                        row_idx
+                    );
                 }
             }
         }
-        info!("Constructed raw condensed feature matrix. Shape: {:?}", raw_condensed_data_matrix.dim());
+        info!(
+            "Constructed raw condensed feature matrix. Shape: {:?}",
+            raw_condensed_data_matrix.dim()
+        );
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         {
@@ -1236,21 +1482,28 @@ impl EigenSNPCoreAlgorithm {
                 if self.config.collect_diagnostics {
                     dc.c_matrix_dims = Some(raw_condensed_data_matrix.dim());
                     if !raw_condensed_data_matrix.is_empty() {
-                        dc.c_matrix_fro_norm = Some(compute_frob_norm_f32(&raw_condensed_data_matrix.view()) as f64);
+                        dc.c_matrix_fro_norm =
+                            Some(compute_frob_norm_f32(&raw_condensed_data_matrix.view()) as f64);
                     } else {
                         dc.c_matrix_fro_norm = Some(0.0);
                     }
                 }
             }
         }
-        Ok(RawCondensedFeatures { data: raw_condensed_data_matrix })
+        Ok(RawCondensedFeatures {
+            data: raw_condensed_data_matrix,
+        })
     }
 
     fn compute_pca_on_standardized_condensed_features_via_rsvd(
         &self,
         standardized_condensed_features: &StandardizedCondensedFeatures,
-        #[cfg(feature = "enable-eigensnp-diagnostics")] mut global_pca_diagnostics_collector: Option<&mut crate::diagnostics::GlobalPcaDiagnostics>,
-        #[cfg(not(feature = "enable-eigensnp-diagnostics"))] mut _global_pca_diagnostics_collector_param: Option<()>, // Renamed to avoid conflict
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        mut global_pca_diagnostics_collector: Option<
+            &mut crate::diagnostics::GlobalPcaDiagnostics,
+        >,
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        mut _global_pca_diagnostics_collector_param: Option<()>, // Renamed to avoid conflict
     ) -> Result<InitialSamplePcScores, ThreadSafeStdError> {
         let a_c = &standardized_condensed_features.data; // A_eigen_std_star
         let m_c = a_c.nrows();
@@ -1260,7 +1513,7 @@ impl EigenSNPCoreAlgorithm {
         let p_glob = self.config.global_pca_sketch_oversampling;
         let q_glob = self.config.global_pca_num_power_iterations; // For RSVD
         let random_seed = self.config.random_seed; // For RSVD
-        
+
         // Initial logging of parameters
         debug!("Initial Global PCA: M_c (condensed features) = {}", m_c);
         debug!("Initial Global PCA: N_samples = {}", n_samples);
@@ -1282,20 +1535,20 @@ impl EigenSNPCoreAlgorithm {
         debug!("Initial Global PCA: L_rsvd calculated: {}", l_rsvd);
         // debug!( // This is a duplicate of a later log, remove if not needed for specific flow tracking
         //     "Initial PCA on condensed features: M_c={}, N_samples={}, K_glob={}, p_glob={}, L_rsvd_raw_sketch={}",
-        //     m_c, n_samples, k_glob, p_glob, k_glob + p_glob 
+        //     m_c, n_samples, k_glob, p_glob, k_glob + p_glob
         // );
         // debug!( // This is also somewhat redundant given the new L_rsvd specific log
         //     "Initial PCA on condensed features: Effective L_rsvd (min with M_c, N_samples) = {}",
         //     l_rsvd
         // );
-        
+
         let direct_svd_m_c_threshold = 500;
         let initial_scores: Array2<f32>;
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         {
             if let Some(gdc) = global_pca_diagnostics_collector.as_mut() {
-                 if self.config.collect_diagnostics {
+                if self.config.collect_diagnostics {
                     gdc.stage_name = "GlobalPCA_Initial".to_string();
                     // Record A_eigen_std_star (a_c) properties
                     if !a_c.is_empty() {
@@ -1303,12 +1556,15 @@ impl EigenSNPCoreAlgorithm {
                         let mut first_step_detail = RsvdStepDetail::default();
                         first_step_detail.step_name = "Input_A_eigen_std".to_string();
                         first_step_detail.input_matrix_dims = Some(a_c.dim());
-                        first_step_detail.fro_norm = Some(compute_frob_norm_f32(&a_c.view()) as f64);
-                        first_step_detail.condition_number = compute_condition_number_via_svd_f32(&a_c.view());
+                        first_step_detail.fro_norm =
+                            Some(compute_frob_norm_f32(&a_c.view()) as f64);
+                        first_step_detail.condition_number =
+                            compute_condition_number_via_svd_f32(&a_c.view());
                         // Also record f64 condition number if desired, perhaps in notes or a dedicated field if added
                         let a_c_f64 = a_c.mapv(|v| v as f64);
                         let cond_f64 = compute_condition_number_via_svd_f64(&a_c_f64.view());
-                        first_step_detail.notes = format!("Input A_eigen_std f64 cond_num: {:?}", cond_f64);
+                        first_step_detail.notes =
+                            format!("Input A_eigen_std f64 cond_num: {:?}", cond_f64);
                         gdc.rsvd_stages.push(first_step_detail);
                     }
                 }
@@ -1319,67 +1575,105 @@ impl EigenSNPCoreAlgorithm {
             info!("Initial Global PCA: Choosing Direct SVD path. Condition: m_c ({}) <= k_glob ({}) || m_c ({}) <= direct_svd_m_c_threshold ({}) || l_rsvd ({}) <= k_glob ({})",
                   m_c, k_glob, m_c, direct_svd_m_c_threshold, l_rsvd, k_glob);
             let a_c_owned_for_svd = a_c.to_owned(); // For SVD
-            
-            debug!("Direct SVD Path: A_c (condensed matrix) dimensions: {:?}", a_c_owned_for_svd.dim());
+
+            debug!(
+                "Direct SVD Path: A_c (condensed matrix) dimensions: {:?}",
+                a_c_owned_for_svd.dim()
+            );
             let backend = LinAlgBackendProvider::<f32>::new();
-            match backend.svd_into(a_c_owned_for_svd.clone(), false, true) { // Clone a_c_owned_for_svd for potential f64 SVD later
+            match backend.svd_into(a_c_owned_for_svd.clone(), false, true) {
+                // Clone a_c_owned_for_svd for potential f64 SVD later
                 Ok(svd_output) => {
                     if let Some(svd_output_vt) = svd_output.vt {
-                         if svd_output_vt.is_empty() {
-                             initial_scores = Array2::zeros((n_samples, 0));
-                         } else {
+                        if svd_output_vt.is_empty() {
+                            initial_scores = Array2::zeros((n_samples, 0));
+                        } else {
                             let num_svd_components = svd_output_vt.nrows();
                             let k_eff = k_glob.min(num_svd_components);
-                            if k_eff == 0 { initial_scores = Array2::zeros((n_samples,0)); }
-                            else {
-                                initial_scores = svd_output_vt.t().slice_axis(Axis(1), ndarray::Slice::from(0..k_eff)).to_owned();
+                            if k_eff == 0 {
+                                initial_scores = Array2::zeros((n_samples, 0));
+                            } else {
+                                initial_scores = svd_output_vt
+                                    .t()
+                                    .slice_axis(Axis(1), ndarray::Slice::from(0..k_eff))
+                                    .to_owned();
                             }
-                         }
-                    } else { /* error handling */ 
+                        }
+                    } else {
+                        /* error handling */
                         warn!("Direct SVD for initial global PCA: svd_output.vt is None despite requesting it. M_c={}, N_samples={}", m_c, n_samples);
-                        return Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, "SVD succeeded but V.T (vt) was not returned by the backend.")) as ThreadSafeStdError);
+                        return Err(Box::new(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            "SVD succeeded but V.T (vt) was not returned by the backend.",
+                        )) as ThreadSafeStdError);
                     }
 
                     #[cfg(feature = "enable-eigensnp-diagnostics")]
                     {
                         if let Some(gdc) = global_pca_diagnostics_collector.as_mut() {
-                            if self.config.collect_diagnostics && !a_c.is_empty() && !initial_scores.is_empty() {
+                            if self.config.collect_diagnostics
+                                && !a_c.is_empty()
+                                && !initial_scores.is_empty()
+                            {
                                 debug!("DIAG: Computing f64 SVD for U_scores_true comparison in Global PCA (Direct SVD Path).");
                                 let a_c_f64_owned = a_c.mapv(|v_f32| v_f32 as f64); // Convert A_c to f64 for true SVD
                                 let backend_f64 = LinAlgBackendProvider::<f64>::new();
-                                match backend_f64.svd_into(a_c_f64_owned, false, true) { // Request VT_f64
+                                match backend_f64.svd_into(a_c_f64_owned, false, true) {
+                                    // Request VT_f64
                                     Ok(svd_out_f64) => {
                                         if let Some(vt_true_f64) = svd_out_f64.vt {
-                                            let k_to_compare = initial_scores.ncols().min(vt_true_f64.nrows());
+                                            let k_to_compare =
+                                                initial_scores.ncols().min(vt_true_f64.nrows());
                                             if k_to_compare > 0 {
-                                                let u_scores_true_f64 = vt_true_f64.t().slice_axis(Axis(1), ndarray::Slice::from(0..k_to_compare)).into_owned();
+                                                let u_scores_true_f64 = vt_true_f64
+                                                    .t()
+                                                    .slice_axis(
+                                                        Axis(1),
+                                                        ndarray::Slice::from(0..k_to_compare),
+                                                    )
+                                                    .into_owned();
                                                 gdc.initial_scores_correlation_vs_py_truth = // Assuming py_truth means f64_truth here
                                                     compute_matrix_column_correlations_abs(&initial_scores.view(), &u_scores_true_f64.view());
                                             }
-                                        } else { gdc.notes.push_str(" ;f64 SVD Vt_true was None for Global PCA truth"); }
+                                        } else {
+                                            gdc.notes.push_str(
+                                                " ;f64 SVD Vt_true was None for Global PCA truth",
+                                            );
+                                        }
                                     }
-                                    Err(e) => { gdc.notes.push_str(&format!(" ;f64 SVD for U_scores_true failed in Global PCA: {}",e)); }
+                                    Err(e) => {
+                                        gdc.notes.push_str(&format!(
+                                            " ;f64 SVD for U_scores_true failed in Global PCA: {}",
+                                            e
+                                        ));
+                                    }
                                 }
                             }
                         }
                     }
                 }
-                Err(e) => { /* error handling */ 
+                Err(e) => {
+                    /* error handling */
                     warn!("Direct SVD failed for initial global PCA (M_c={}, N_samples={}): {}. Returning error.", m_c, n_samples, e);
-                    return Err(Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("Direct SVD failed during initial global PCA: {}", e))) as ThreadSafeStdError);
+                    return Err(Box::new(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!("Direct SVD failed during initial global PCA: {}", e),
+                    )) as ThreadSafeStdError);
                 }
             }
         } else {
             info!("Initial Global PCA: Choosing RSVD path. Condition: m_c ({}) > k_glob ({}) && m_c ({}) > direct_svd_m_c_threshold ({}) && l_rsvd ({}) > k_glob ({})",
                   m_c, k_glob, m_c, direct_svd_m_c_threshold, l_rsvd, k_glob);
-            
+
             #[cfg(feature = "enable-eigensnp-diagnostics")]
-            let rsvd_stages_collector = global_pca_diagnostics_collector.as_mut().map(|gdc| &mut gdc.rsvd_stages);
+            let rsvd_stages_collector = global_pca_diagnostics_collector
+                .as_mut()
+                .map(|gdc| &mut gdc.rsvd_stages);
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
             let rsvd_stages_collector = None;
 
             initial_scores = Self::perform_randomized_svd_for_scores(
-                &a_c.view(), 
+                &a_c.view(),
                 k_glob,
                 p_glob,
                 q_glob,
@@ -1387,40 +1681,47 @@ impl EigenSNPCoreAlgorithm {
                 rsvd_stages_collector,
             )?;
         }
-        
+
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         {
             if let Some(gdc) = global_pca_diagnostics_collector.as_mut() {
-                 if self.config.collect_diagnostics && !initial_scores.is_empty() {
+                if self.config.collect_diagnostics && !initial_scores.is_empty() {
                     // Record initial_scores properties (assuming initial_scores is U_scores_star)
                     // gdc.initial_scores_dims = Some(initial_scores.dim()); // This field does not exist
                     // gdc.initial_scores_fro_norm = Some(compute_frob_norm_f32(&initial_scores.view()) as f64); // This field does not exist
                     // gdc.initial_scores_orthogonality_error = compute_orthogonality_error_f32(&initial_scores.view()); // This field does not exist
                     // Storing these in notes for now, or they could be the last RsvdStepDetail from perform_randomized_svd_for_scores
-                    let (r,c) = initial_scores.dim();
+                    let (r, c) = initial_scores.dim();
                     let fro_norm = compute_frob_norm_f32(&initial_scores.view()) as f64;
                     let ortho_error = compute_orthogonality_error_f32(&initial_scores.view());
-                    gdc.notes.push_str(&format!(" ;InitialScores dims:({},{}), FrobNorm:{:.4e}, OrthoError:{:?}",r,c,fro_norm,ortho_error));
+                    gdc.notes.push_str(&format!(
+                        " ;InitialScores dims:({},{}), FrobNorm:{:.4e}, OrthoError:{:?}",
+                        r, c, fro_norm, ortho_error
+                    ));
                 }
             }
         }
-        
+
         if initial_scores.ncols() == 0 && k_glob > 0 {
             warn!("Initial PCA scores have 0 columns (M_c={}, N_samples={}), but k_glob ({}) > 0. This might indicate an issue or empty input.", m_c, n_samples, k_glob);
         }
 
-        Ok(InitialSamplePcScores { scores: initial_scores })
+        Ok(InitialSamplePcScores {
+            scores: initial_scores,
+        })
     }
 
     /// Computes the right singular vectors (V_A_approx, sample scores) of a matrix A using rSVD.
     /// A is M features x N samples. Output is N x K_eff.
     pub fn perform_randomized_svd_for_scores(
-        matrix_features_by_samples: &ArrayView2<f32>, 
+        matrix_features_by_samples: &ArrayView2<f32>,
         num_components_target_k: usize,
         sketch_oversampling_count: usize,
         num_power_iterations: usize,
         random_seed: u64,
-        #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector: Option<&mut Vec<crate::diagnostics::RsvdStepDetail>>,
+        #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector: Option<
+            &mut Vec<crate::diagnostics::RsvdStepDetail>,
+        >,
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector: Option<()>,
     ) -> Result<Array2<f32>, ThreadSafeStdError> {
         let (_u_opt, _s_opt, v_opt) = Self::_internal_perform_rsvd(
@@ -1432,10 +1733,12 @@ impl EigenSNPCoreAlgorithm {
             false, // request_u_components
             false, // request_s_components
             true,  // request_v_components
-            #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector,
-            #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector,
+            #[cfg(feature = "enable-eigensnp-diagnostics")]
+            _diagnostics_collector,
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+            _diagnostics_collector,
         )?;
-        
+
         // if let (Some(collector), Some(diag)) = (diagnostics_collector, step_diag) {
         //    if self.config.collect_diagnostics { collector.push(diag); }
         // }
@@ -1456,7 +1759,9 @@ impl EigenSNPCoreAlgorithm {
         sketch_oversampling_count: usize,
         num_power_iterations: usize,
         random_seed: u64,
-        #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector: Option<&mut Vec<crate::diagnostics::RsvdStepDetail>>,
+        #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector: Option<
+            &mut Vec<crate::diagnostics::RsvdStepDetail>,
+        >,
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector: Option<()>,
     ) -> Result<Array2<f32>, ThreadSafeStdError> {
         let (u_opt, _s_opt, _v_opt) = Self::_internal_perform_rsvd(
@@ -1468,8 +1773,10 @@ impl EigenSNPCoreAlgorithm {
             true,  // request_u_components
             false, // request_s_components
             false, // request_v_components
-            #[cfg(feature = "enable-eigensnp-diagnostics")] _diagnostics_collector,
-            #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector,
+            #[cfg(feature = "enable-eigensnp-diagnostics")]
+            _diagnostics_collector,
+            #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+            _diagnostics_collector,
         )?;
 
         // if let (Some(collector), Some(diag)) = (diagnostics_collector, step_diag) {
@@ -1483,7 +1790,7 @@ impl EigenSNPCoreAlgorithm {
             )) as ThreadSafeStdError
         })
     }
-    
+
     /// Performs matrix multiplication of A.T * B (A: D_strip x N, B: D_strip x K_qr)
     /// using f64 accumulation for each element of the resulting f32 matrix (N x K_qr).
     fn dot_product_at_b_mixed_precision(
@@ -1513,57 +1820,60 @@ impl EigenSNPCoreAlgorithm {
         let mut result_n_x_kqr_f32 = Array2::<f32>::zeros((n_samples, k_qr));
 
         result_n_x_kqr_f32
-            .axis_iter_mut(Axis(0)) 
+            .axis_iter_mut(Axis(0))
             .into_par_iter()
-            .enumerate() 
+            .enumerate()
             .for_each(|(i_sample_idx, mut output_row_f32_view)| {
                 let a_col_i_view = matrix_a_dstrip_x_n.column(i_sample_idx);
                 // Slices are no longer obtained here. Loading is done manually into arrays.
 
-                for k_comp_idx in 0..k_qr { 
+                for k_comp_idx in 0..k_qr {
                     let mut accumulator_f64: f64 = 0.0;
                     let b_col_k_view = matrix_b_dstrip_x_kqr.column(k_comp_idx);
                     // Slice for b_col_k_view is also removed.
-                    
+
                     let num_simd_chunks = d_strip / LANES;
                     let mut simd_f32_partial_sum = Simd::splat(0.0f32);
 
                     for chunk_idx in 0..num_simd_chunks {
                         let offset = chunk_idx * LANES;
-                        
+
                         let mut a_temp_array = [0.0f32; LANES];
                         for lane_idx in 0..LANES {
                             a_temp_array[lane_idx] = a_col_i_view[offset + lane_idx];
                         }
                         let a_simd = Simd::from_array(a_temp_array);
-                        
+
                         let mut b_temp_array = [0.0f32; LANES];
                         for lane_idx in 0..LANES {
                             b_temp_array[lane_idx] = b_col_k_view[offset + lane_idx];
                         }
                         let b_simd = Simd::from_array(b_temp_array);
-                        
+
                         simd_f32_partial_sum += a_simd * b_simd;
                     }
                     accumulator_f64 += simd_f32_partial_sum.reduce_sum() as f64;
 
-                    for d_snp_idx in (num_simd_chunks * LANES)..d_strip { 
-                        accumulator_f64 += (a_col_i_view[d_snp_idx] as f64) * (b_col_k_view[d_snp_idx] as f64);
+                    for d_snp_idx in (num_simd_chunks * LANES)..d_strip {
+                        accumulator_f64 +=
+                            (a_col_i_view[d_snp_idx] as f64) * (b_col_k_view[d_snp_idx] as f64);
                     }
                     output_row_f32_view[k_comp_idx] = accumulator_f64 as f32;
                 }
             });
-            
+
         Ok(result_n_x_kqr_f32)
     }
-
 
     fn compute_refined_snp_loadings<G: PcaReadyGenotypeAccessor>(
         &self,
         genotype_data: &G,
         initial_sample_pc_scores: &InitialSamplePcScores,
-        #[cfg(feature = "enable-eigensnp-diagnostics")] mut pass_diagnostics_collector: Option<&mut crate::diagnostics::SrPassDetail>,
-        #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _pass_diagnostics_collector_param: Option<()>, // Renamed
+        #[cfg(feature = "enable-eigensnp-diagnostics")] mut pass_diagnostics_collector: Option<
+            &mut crate::diagnostics::SrPassDetail,
+        >,
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        _pass_diagnostics_collector_param: Option<()>, // Renamed
     ) -> Result<Array2<f32>, ThreadSafeStdError> {
         // Computes $V_{QR}^* = X U_{scores}^*$, where $X$ is D_blocked x N and $U_{scores}^*$ is N x K_initial.
         // The result $V_{QR}^*$ is D_blocked x K_initial.
@@ -1576,7 +1886,7 @@ impl EigenSNPCoreAlgorithm {
         // elements in an `f64` accumulator, and then casts the final sum back to `f32`.
         // This approach enhances numerical precision for the sum over the $N$ dimension
         // (number of samples) compared to a pure `f32` accumulation (e.g., via `sgemm`).
-        let initial_scores_n_by_k_initial = &initial_sample_pc_scores.scores; 
+        let initial_scores_n_by_k_initial = &initial_sample_pc_scores.scores;
         let num_qc_samples = initial_scores_n_by_k_initial.nrows();
         let num_computed_initial_pcs = initial_scores_n_by_k_initial.ncols();
         let num_total_pca_snps = genotype_data.num_pca_snps();
@@ -1595,21 +1905,23 @@ impl EigenSNPCoreAlgorithm {
             return Ok(Array2::zeros((0, num_computed_initial_pcs)));
         }
 
-        let mut snp_loadings_before_ortho_pca_snps_by_components = 
+        let mut snp_loadings_before_ortho_pca_snps_by_components =
             Array2::<f32>::zeros((num_total_pca_snps, num_computed_initial_pcs));
         let all_qc_sample_ids: Vec<QcSampleId> = (0..num_qc_samples).map(QcSampleId).collect();
-        
+
         // Use the configured strip size, ensuring it's at least 1 and not more than total SNPs.
-        let snp_processing_strip_size = self.config.snp_processing_strip_size
+        let snp_processing_strip_size = self
+            .config
+            .snp_processing_strip_size
             .min(num_total_pca_snps)
             .max(1);
-        
+
         if snp_processing_strip_size > 0 {
             snp_loadings_before_ortho_pca_snps_by_components
                 .axis_chunks_iter_mut(Axis(0), snp_processing_strip_size)
                 .into_par_iter()
                 .enumerate()
-                .try_for_each(|(strip_index, mut loadings_strip_view_mut)| 
+                .try_for_each(|(strip_index, mut loadings_strip_view_mut)|
                     -> Result<(), ThreadSafeStdError> {
                     let strip_start_snp_idx = strip_index * snp_processing_strip_size;
                     let num_snps_in_current_strip = loadings_strip_view_mut.nrows();
@@ -1624,7 +1936,7 @@ impl EigenSNPCoreAlgorithm {
                         &snp_ids_in_strip,
                         &all_qc_sample_ids,
                     ).map_err(|e_accessor| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to get standardized SNP/sample block during refined SNP loading for strip index {}: {}", strip_index, e_accessor))) as ThreadSafeStdError)?;
-                        
+
                     // Perform dot product with f64 accumulation
                     let snp_loadings_for_strip = Self::dot_product_mixed_precision_f32_f64acc(
                         &genotype_data_strip_snps_by_samples.view(),
@@ -1634,19 +1946,24 @@ impl EigenSNPCoreAlgorithm {
                     Ok(())
                 })?;
         }
-        
+
         if snp_loadings_before_ortho_pca_snps_by_components.ncols() == 0 {
             info!("Refined loadings matrix has 0 columns, QR skipped.");
             return Ok(snp_loadings_before_ortho_pca_snps_by_components);
         }
-        
+
         let backend = LinAlgBackendProvider::<f32>::new(); // Use LinAlgBackendProvider for f32
-        let orthonormal_snp_loadings = backend.qr_q_factor(&snp_loadings_before_ortho_pca_snps_by_components)
+        let orthonormal_snp_loadings = backend
+            .qr_q_factor(&snp_loadings_before_ortho_pca_snps_by_components)
             .map_err(|e_qr| -> ThreadSafeStdError {
                 std::io::Error::new(
                     std::io::ErrorKind::Other,
-                    format!("QR decomposition of refined loadings failed (via backend): {}", e_qr)
-                ).into()
+                    format!(
+                        "QR decomposition of refined loadings failed (via backend): {}",
+                        e_qr
+                    ),
+                )
+                .into()
             })?;
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
@@ -1658,33 +1975,44 @@ impl EigenSNPCoreAlgorithm {
                     // For now, assume V_hat is the input scores to this stage
                     pdc.v_hat_dims = Some(initial_scores_n_by_k_initial.dim());
                     if !initial_scores_n_by_k_initial.is_empty() {
-                         pdc.v_hat_orthogonality_error = compute_orthogonality_error_f32(&initial_scores_n_by_k_initial.view());
+                        pdc.v_hat_orthogonality_error =
+                            compute_orthogonality_error_f32(&initial_scores_n_by_k_initial.view());
                     }
                     // L_raw_star is snp_loadings_before_ortho_pca_snps_by_components
                     // This matrix is D x K_initial. S_intermediate in SrPassDetail is N x K_prev_eigenvecs
                     // The naming here is a bit confusing. Let's record L_raw_star's condition number in notes for now.
                     if !snp_loadings_before_ortho_pca_snps_by_components.is_empty() {
-                        let cond_num_l_raw = compute_condition_number_via_svd_f32(&snp_loadings_before_ortho_pca_snps_by_components.view());
-                        pdc.notes.push_str(&format!("L_raw_star (SNP loadings pre-QR) cond_num: {:?}; ", cond_num_l_raw));
+                        let cond_num_l_raw = compute_condition_number_via_svd_f32(
+                            &snp_loadings_before_ortho_pca_snps_by_components.view(),
+                        );
+                        pdc.notes.push_str(&format!(
+                            "L_raw_star (SNP loadings pre-QR) cond_num: {:?}; ",
+                            cond_num_l_raw
+                        ));
                     }
                     // V_qr_star is orthonormal_snp_loadings (D x K_eff)
                     // This is the Q factor of V_hat in the notation S_intermediate = C_std @ V_hat_Q
                     // Let's use s_intermediate_dims for V_qr_star (orthonormal_snp_loadings)
                     pdc.s_intermediate_dims = Some(orthonormal_snp_loadings.dim()); // This is V_qr*
-                     if !orthonormal_snp_loadings.is_empty() {
-                        pdc.s_intermediate_fro_norm = Some(compute_frob_norm_f32(&orthonormal_snp_loadings.view()) as f64);
+                    if !orthonormal_snp_loadings.is_empty() {
+                        pdc.s_intermediate_fro_norm =
+                            Some(compute_frob_norm_f32(&orthonormal_snp_loadings.view()) as f64);
                         // Orthogonality error for V_qr_star (orthonormal_snp_loadings)
                         // This is U_s in SrPassDetail if we consider V_qr* = U_s S_s V_s^T, but here it's just a Q factor.
                         // The field u_s_orthogonality_error or v_hat_orthogonality_error could be used.
                         // Let's use v_hat_orthogonality_error for the input `initial_sample_pc_scores`
                         // and u_s_orthogonality_error for the output `orthonormal_snp_loadings` (which is V_QR*).
-                        pdc.u_s_orthogonality_error = compute_orthogonality_error_f32(&orthonormal_snp_loadings.view());
+                        pdc.u_s_orthogonality_error =
+                            compute_orthogonality_error_f32(&orthonormal_snp_loadings.view());
                     }
                 }
             }
         }
-        
-        info!("Computed refined SNP loadings. Shape: {:?}", orthonormal_snp_loadings.dim());
+
+        info!(
+            "Computed refined SNP loadings. Shape: {:?}",
+            orthonormal_snp_loadings.dim()
+        );
         Ok(orthonormal_snp_loadings)
     }
 
@@ -1692,9 +2020,12 @@ impl EigenSNPCoreAlgorithm {
         &self,
         genotype_data: &G,
         v_qr_loadings_d_by_k: &ArrayView2<f32>, // V_qr (D x K_initial)
-        num_total_qc_samples: usize, // N
-        #[cfg(feature = "enable-eigensnp-diagnostics")] mut pass_diagnostics_collector: Option<&mut crate::diagnostics::SrPassDetail>,
-        #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _pass_diagnostics_collector_param: Option<()>, // Renamed
+        num_total_qc_samples: usize,            // N
+        #[cfg(feature = "enable-eigensnp-diagnostics")] mut pass_diagnostics_collector: Option<
+            &mut crate::diagnostics::SrPassDetail,
+        >,
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        _pass_diagnostics_collector_param: Option<()>, // Renamed
     ) -> Result<(Array2<f32>, Array1<f64>, Array2<f32>), ThreadSafeStdError> {
         let num_total_pca_snps = v_qr_loadings_d_by_k.nrows(); // D
         let k_initial_components = v_qr_loadings_d_by_k.ncols(); // K_initial
@@ -1714,7 +2045,10 @@ impl EigenSNPCoreAlgorithm {
             ));
         }
         if num_total_pca_snps == 0 {
-            debug!("No PCA SNPs (D=0), returning empty results for {} initial components.", k_initial_components);
+            debug!(
+                "No PCA SNPs (D=0), returning empty results for {} initial components.",
+                k_initial_components
+            );
             return Ok((
                 Array2::zeros((num_total_qc_samples, k_initial_components)),
                 Array1::zeros(k_initial_components),
@@ -1722,7 +2056,10 @@ impl EigenSNPCoreAlgorithm {
             ));
         }
         if num_total_qc_samples == 0 {
-            debug!("No QC samples (N=0), returning empty results for {} initial components.", k_initial_components);
+            debug!(
+                "No QC samples (N=0), returning empty results for {} initial components.",
+                k_initial_components
+            );
             return Ok((
                 Array2::zeros((0, k_initial_components)),
                 Array1::zeros(k_initial_components),
@@ -1732,7 +2069,9 @@ impl EigenSNPCoreAlgorithm {
 
         // --- B. Calculate Intermediate Scores (S_intermediate = X^T · V_qr) with f64 Accumulation ---
         // Use the configured strip size, ensuring it's at least 1 and not more than total SNPs.
-        let snp_processing_strip_size = self.config.snp_processing_strip_size
+        let snp_processing_strip_size = self
+            .config
+            .snp_processing_strip_size
             .min(num_total_pca_snps)
             .max(1);
         let all_qc_sample_ids_for_scores: Vec<QcSampleId> =
@@ -1744,37 +2083,59 @@ impl EigenSNPCoreAlgorithm {
 
         let s_intermediate_n_by_k_initial_f64: Array2<f64> = strip_indices_starts
             .par_iter()
-            .map(|&strip_start_snp_idx| -> Result<Array2<f64>, ThreadSafeStdError> {
-                let strip_end_snp_idx = (strip_start_snp_idx + snp_processing_strip_size).min(num_total_pca_snps);
-                if strip_start_snp_idx >= strip_end_snp_idx {
-                    return Ok(Array2::<f64>::zeros((num_total_qc_samples, k_initial_components)));
-                }
+            .map(
+                |&strip_start_snp_idx| -> Result<Array2<f64>, ThreadSafeStdError> {
+                    let strip_end_snp_idx =
+                        (strip_start_snp_idx + snp_processing_strip_size).min(num_total_pca_snps);
+                    if strip_start_snp_idx >= strip_end_snp_idx {
+                        return Ok(Array2::<f64>::zeros((
+                            num_total_qc_samples,
+                            k_initial_components,
+                        )));
+                    }
 
-                let snp_ids_in_strip: Vec<PcaSnpId> =
-                    (strip_start_snp_idx..strip_end_snp_idx).map(PcaSnpId).collect();
+                    let snp_ids_in_strip: Vec<PcaSnpId> = (strip_start_snp_idx..strip_end_snp_idx)
+                        .map(PcaSnpId)
+                        .collect();
 
-                let genotype_data_strip_f32 = genotype_data.get_standardized_snp_sample_block(
-                    &snp_ids_in_strip,
-                    &all_qc_sample_ids_for_scores,
-                ).map_err(|_e_original_error| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("Failed to get genotype block for strip {}-{}", strip_start_snp_idx, strip_end_snp_idx))) as ThreadSafeStdError)?; // D_strip x N (f32)
-                
-                let v_qr_loadings_for_strip_f32 = v_qr_loadings_d_by_k
-                    .slice(s![strip_start_snp_idx..strip_end_snp_idx, ..]); // D_strip x K_initial (f32)
+                    let genotype_data_strip_f32 = genotype_data
+                        .get_standardized_snp_sample_block(
+                            &snp_ids_in_strip,
+                            &all_qc_sample_ids_for_scores,
+                        )
+                        .map_err(|_e_original_error| {
+                            Box::new(std::io::Error::new(
+                                std::io::ErrorKind::Other,
+                                format!(
+                                    "Failed to get genotype block for strip {}-{}",
+                                    strip_start_snp_idx, strip_end_snp_idx
+                                ),
+                            )) as ThreadSafeStdError
+                        })?; // D_strip x N (f32)
 
-                // S_intermediate_strip = X_strip^T · V_qr_strip
-                // X_strip is genotype_data_strip_f32 (D_strip x N)
-                // V_qr_strip is v_qr_loadings_for_strip_f32 (D_strip x K_initial)
-                // Result should be N x K_initial
-                let s_intermediate_strip_f32 = Self::dot_product_at_b_mixed_precision(
-                    &genotype_data_strip_f32.view(),      // This is A (D_strip x N)
-                    &v_qr_loadings_for_strip_f32.view()   // This is B (D_strip x K_QR/K_initial)
-                )?; // Result is N x K_initial, f32 (computed with f64 accumulation)
-                
-                // Cast to f64 for outer sum over strips
-                Ok(s_intermediate_strip_f32.mapv(|x| x as f64))
-            })
+                    let v_qr_loadings_for_strip_f32 =
+                        v_qr_loadings_d_by_k.slice(s![strip_start_snp_idx..strip_end_snp_idx, ..]); // D_strip x K_initial (f32)
+
+                    // S_intermediate_strip = X_strip^T · V_qr_strip
+                    // X_strip is genotype_data_strip_f32 (D_strip x N)
+                    // V_qr_strip is v_qr_loadings_for_strip_f32 (D_strip x K_initial)
+                    // Result should be N x K_initial
+                    let s_intermediate_strip_f32 = Self::dot_product_at_b_mixed_precision(
+                        &genotype_data_strip_f32.view(),     // This is A (D_strip x N)
+                        &v_qr_loadings_for_strip_f32.view(), // This is B (D_strip x K_QR/K_initial)
+                    )?; // Result is N x K_initial, f32 (computed with f64 accumulation)
+
+                    // Cast to f64 for outer sum over strips
+                    Ok(s_intermediate_strip_f32.mapv(|x| x as f64))
+                },
+            )
             .fold(
-                || Ok(Array2::<f64>::zeros((num_total_qc_samples, k_initial_components))), // Identity for fold (per-thread accumulator)
+                || {
+                    Ok(Array2::<f64>::zeros((
+                        num_total_qc_samples,
+                        k_initial_components,
+                    )))
+                }, // Identity for fold (per-thread accumulator)
                 |acc_result, next_result| {
                     match (acc_result, next_result) {
                         (Ok(mut acc_matrix), Ok(next_matrix)) => {
@@ -1787,16 +2148,19 @@ impl EigenSNPCoreAlgorithm {
                 },
             )
             .reduce(
-                || Ok(Array2::<f64>::zeros((num_total_qc_samples, k_initial_components))), // Identity for reduce
-                |final_acc_result, thread_acc_result| {
-                     match (final_acc_result, thread_acc_result) {
-                        (Ok(mut final_acc), Ok(thread_acc)) => {
-                            final_acc += &thread_acc;
-                            Ok(final_acc)
-                        }
-                        (Err(e), _) => Err(e),
-                        (_, Err(e)) => Err(e),
+                || {
+                    Ok(Array2::<f64>::zeros((
+                        num_total_qc_samples,
+                        k_initial_components,
+                    )))
+                }, // Identity for reduce
+                |final_acc_result, thread_acc_result| match (final_acc_result, thread_acc_result) {
+                    (Ok(mut final_acc), Ok(thread_acc)) => {
+                        final_acc += &thread_acc;
+                        Ok(final_acc)
                     }
+                    (Err(e), _) => Err(e),
+                    (_, Err(e)) => Err(e),
                 },
             )?; // Corrected: Only one ? needed as reduce itself returns a single Result.
 
@@ -1809,15 +2173,19 @@ impl EigenSNPCoreAlgorithm {
                     // Record diagnostics for s_intermediate_n_by_k_initial_f64 BEFORE it's moved.
                     pdc.s_intermediate_dims = Some(s_intermediate_n_by_k_initial_f64.dim());
                     if !s_intermediate_n_by_k_initial_f64.is_empty() {
-                        pdc.s_intermediate_fro_norm = Some(compute_frob_norm_f64(&s_intermediate_n_by_k_initial_f64.view()));
+                        pdc.s_intermediate_fro_norm = Some(compute_frob_norm_f64(
+                            &s_intermediate_n_by_k_initial_f64.view(),
+                        ));
                         // Note: Computing condition number here might be expensive or redundant if already done.
                         // For now, let's assume it's desired.
-                        pdc.s_intermediate_condition_number = compute_condition_number_via_svd_f64(&s_intermediate_n_by_k_initial_f64.view());
+                        pdc.s_intermediate_condition_number = compute_condition_number_via_svd_f64(
+                            &s_intermediate_n_by_k_initial_f64.view(),
+                        );
                     }
                 }
             }
         }
-        
+
         // Instantiate LinAlgBackendProvider for f64
         let backend_svd_f64 = LinAlgBackendProvider::<f64>::new();
         debug!(
@@ -1826,30 +2194,45 @@ impl EigenSNPCoreAlgorithm {
         );
 
         // SVD on f64 matrix
-        let svd_output_f64 = backend_svd_f64.svd_into(
-            s_intermediate_n_by_k_initial_f64, // Consumes matrix (Array2<f64>)
-            true, // compute U_rot
-            true, // compute V_rot_transposed
-        ).map_err(|e_svd| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("SVD (f64) of S_intermediate failed: {}", e_svd))) as ThreadSafeStdError)?;
+        let svd_output_f64 = backend_svd_f64
+            .svd_into(
+                s_intermediate_n_by_k_initial_f64, // Consumes matrix (Array2<f64>)
+                true,                              // compute U_rot
+                true,                              // compute V_rot_transposed
+            )
+            .map_err(|e_svd| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("SVD (f64) of S_intermediate failed: {}", e_svd),
+                )) as ThreadSafeStdError
+            })?;
 
         // SVD results are now f64
-        let u_rot_n_by_k_eff_from_svd_f64 = svd_output_f64.u.ok_or_else(|| 
-            Box::new(std::io::Error::new(std::io::ErrorKind::Other, "SVD U_rot (f64) (from S_intermediate) not returned")) as ThreadSafeStdError)?;
-        
+        let u_rot_n_by_k_eff_from_svd_f64 = svd_output_f64.u.ok_or_else(|| {
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "SVD U_rot (f64) (from S_intermediate) not returned",
+            )) as ThreadSafeStdError
+        })?;
+
         let s_prime_singular_values_k_eff_from_svd_f64 = svd_output_f64.s; // This is Array1<f64>
-        
-        let vt_rot_k_eff_by_k_initial_from_svd_f64 = svd_output_f64.vt.ok_or_else(||
-             Box::new(std::io::Error::new(std::io::ErrorKind::Other, "SVD V_rot.T (f64) (from S_intermediate) not returned")) as ThreadSafeStdError)?;
+
+        let vt_rot_k_eff_by_k_initial_from_svd_f64 = svd_output_f64.vt.ok_or_else(|| {
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "SVD V_rot.T (f64) (from S_intermediate) not returned",
+            )) as ThreadSafeStdError
+        })?;
 
         // Mutable versions for potential slicing
         let mut u_rot_n_by_k_eff_f64 = u_rot_n_by_k_eff_from_svd_f64;
         let mut s_prime_singular_values_k_eff_f64 = s_prime_singular_values_k_eff_from_svd_f64;
         let mut vt_rot_k_eff_by_k_initial_f64 = vt_rot_k_eff_by_k_initial_from_svd_f64;
-        
+
         // --- Determine consistent number of effective components (num_components_to_process) ---
         let k_eff_from_u_f64 = u_rot_n_by_k_eff_f64.ncols();
         let k_eff_from_s_f64 = s_prime_singular_values_k_eff_f64.len();
-        
+
         let num_components_to_process = k_eff_from_u_f64.min(k_eff_from_s_f64);
 
         if k_eff_from_u_f64 != k_eff_from_s_f64 {
@@ -1858,13 +2241,13 @@ impl EigenSNPCoreAlgorithm {
                 k_eff_from_u_f64, k_eff_from_s_f64, num_components_to_process
             );
         }
-        
+
         if num_components_to_process == 0 {
             debug!("SVD (f64) of S_intermediate resulted in num_components_to_process = 0. Returning empty results.");
             return Ok((
                 Array2::zeros((num_total_qc_samples, 0)), // f32 for final output
-                Array1::zeros(0), // f64 for eigenvalues
-                Array2::zeros((num_total_pca_snps, 0)), // f32 for final output
+                Array1::zeros(0),                         // f64 for eigenvalues
+                Array2::zeros((num_total_pca_snps, 0)),   // f32 for final output
             ));
         }
 
@@ -1872,11 +2255,17 @@ impl EigenSNPCoreAlgorithm {
 
         // Slice SVD outputs (f64) if necessary
         if k_eff_from_u_f64 > num_components_to_process {
-            u_rot_n_by_k_eff_f64 = u_rot_n_by_k_eff_f64.slice_axis(Axis(1), ndarray::Slice::from(0..num_components_to_process)).into_owned();
+            u_rot_n_by_k_eff_f64 = u_rot_n_by_k_eff_f64
+                .slice_axis(Axis(1), ndarray::Slice::from(0..num_components_to_process))
+                .into_owned();
         }
         if k_eff_from_s_f64 > num_components_to_process {
-            s_prime_singular_values_k_eff_f64 = s_prime_singular_values_k_eff_f64.slice(s![0..num_components_to_process]).into_owned();
-            vt_rot_k_eff_by_k_initial_f64 = vt_rot_k_eff_by_k_initial_f64.slice_axis(Axis(0), ndarray::Slice::from(0..num_components_to_process)).into_owned();
+            s_prime_singular_values_k_eff_f64 = s_prime_singular_values_k_eff_f64
+                .slice(s![0..num_components_to_process])
+                .into_owned();
+            vt_rot_k_eff_by_k_initial_f64 = vt_rot_k_eff_by_k_initial_f64
+                .slice_axis(Axis(0), ndarray::Slice::from(0..num_components_to_process))
+                .into_owned();
         }
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
@@ -1885,36 +2274,43 @@ impl EigenSNPCoreAlgorithm {
                 if self.config.collect_diagnostics {
                     // Record diagnostics for u_rot_n_by_k_eff_f64 BEFORE it's moved.
                     if !u_rot_n_by_k_eff_f64.is_empty() {
-                         let u_rot_f32_for_ortho = u_rot_n_by_k_eff_f64.mapv(|x_f64| x_f64 as f32);
-                         pdc.u_s_orthogonality_error = compute_orthogonality_error_f32(&u_rot_f32_for_ortho.view());
+                        let u_rot_f32_for_ortho = u_rot_n_by_k_eff_f64.mapv(|x_f64| x_f64 as f32);
+                        pdc.u_s_orthogonality_error =
+                            compute_orthogonality_error_f32(&u_rot_f32_for_ortho.view());
                     }
                     // Other diagnostics that might depend on u_rot_n_by_k_eff_f64 before move
-                    pdc.s_intermediate_num_singular_values = Some(s_prime_singular_values_k_eff_f64.len());
-                    pdc.s_intermediate_singular_values_sample = sample_singular_values_f64(&s_prime_singular_values_k_eff_f64.view(), 10);
+                    pdc.s_intermediate_num_singular_values =
+                        Some(s_prime_singular_values_k_eff_f64.len());
+                    pdc.s_intermediate_singular_values_sample =
+                        sample_singular_values_f64(&s_prime_singular_values_k_eff_f64.view(), 10);
                 }
             }
         }
-        
+
         // Final Sample Scores: S_final^* = U_small * Sigma_small (f64)
         let mut final_sample_scores_n_by_k_eff_f64 = u_rot_n_by_k_eff_f64; // N x num_components_to_process (f64)
         if num_components_to_process > 0 {
             for k_idx in 0..num_components_to_process {
                 let singular_value_for_scaling_f64 = s_prime_singular_values_k_eff_f64[k_idx];
-                let mut score_column_to_scale_f64 = final_sample_scores_n_by_k_eff_f64.column_mut(k_idx);
-                score_column_to_scale_f64.mapv_inplace(|element_val| element_val * singular_value_for_scaling_f64);
+                let mut score_column_to_scale_f64 =
+                    final_sample_scores_n_by_k_eff_f64.column_mut(k_idx);
+                score_column_to_scale_f64
+                    .mapv_inplace(|element_val| element_val * singular_value_for_scaling_f64);
             }
         }
         // Cast final scores to f32
-        let final_sample_scores_n_by_k_eff_f32 = final_sample_scores_n_by_k_eff_f64.mapv(|x| x as f32);
-        
+        let final_sample_scores_n_by_k_eff_f32 =
+            final_sample_scores_n_by_k_eff_f64.mapv(|x| x as f32);
+
         // Final SNP Loadings: V_final = V_qr * V_rot (f32 * f64 -> needs adjustment)
         // V_qr is D x K_initial (f32)
         // V_rot is K_initial x num_components_to_process (f64, from vt_rot_f64.t())
         let v_rot_k_initial_by_k_eff_f64 = vt_rot_k_eff_by_k_initial_f64.t().into_owned();
         // Cast V_rot to f32 before dot product
         let v_rot_k_initial_by_k_eff_f32 = v_rot_k_initial_by_k_eff_f64.mapv(|x| x as f32);
-        let final_snp_loadings_d_by_k_eff_f32 = v_qr_loadings_d_by_k.dot(&v_rot_k_initial_by_k_eff_f32);
-        
+        let final_snp_loadings_d_by_k_eff_f32 =
+            v_qr_loadings_d_by_k.dot(&v_rot_k_initial_by_k_eff_f32);
+
         // Final Eigenvalues: lambda_k = s_prime_k^2 / (N-1) (f64)
         let denominator_n_minus_1 = (num_total_qc_samples as f64 - 1.0).max(1.0);
         let final_eigenvalues_k_eff_f64 = s_prime_singular_values_k_eff_f64.mapv(|s_val_f64| {
@@ -1926,24 +2322,40 @@ impl EigenSNPCoreAlgorithm {
         // final_eigenvalues_k_eff_f64 is Array1<f64>
         // final_sample_scores_n_by_k_eff_f32 is Array2<f32>
         // final_snp_loadings_d_by_k_eff_f32 is Array2<f32>
-        
+
         let mut an_eigenvalue_index_pairs: Vec<(f64, usize)> = final_eigenvalues_k_eff_f64
             .iter()
             .enumerate()
             .map(|(idx, &val)| (val, idx))
             .collect();
-        
-        an_eigenvalue_index_pairs.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-        
-        let sorted_indices: Vec<usize> = an_eigenvalue_index_pairs.into_iter().map(|pair| pair.1).collect();
 
-        let sorted_final_sample_scores = reorder_columns_owned(&final_sample_scores_n_by_k_eff_f32, &sorted_indices);
-        let sorted_final_snp_loadings = reorder_columns_owned(&final_snp_loadings_d_by_k_eff_f32, &sorted_indices);
-        let sorted_final_eigenvalues = reorder_array_owned(&final_eigenvalues_k_eff_f64, &sorted_indices);
-        
-        debug!("Computed final sorted eigenvalues: {:?}", sorted_final_eigenvalues);
-        info!("Computed final sorted sample scores. Shape: {:?}", sorted_final_sample_scores.dim());
-        info!("Computed final sorted SNP loadings. Shape: {:?}", sorted_final_snp_loadings.dim());
+        an_eigenvalue_index_pairs
+            .sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
+
+        let sorted_indices: Vec<usize> = an_eigenvalue_index_pairs
+            .into_iter()
+            .map(|pair| pair.1)
+            .collect();
+
+        let sorted_final_sample_scores =
+            reorder_columns_owned(&final_sample_scores_n_by_k_eff_f32, &sorted_indices);
+        let sorted_final_snp_loadings =
+            reorder_columns_owned(&final_snp_loadings_d_by_k_eff_f32, &sorted_indices);
+        let sorted_final_eigenvalues =
+            reorder_array_owned(&final_eigenvalues_k_eff_f64, &sorted_indices);
+
+        debug!(
+            "Computed final sorted eigenvalues: {:?}",
+            sorted_final_eigenvalues
+        );
+        info!(
+            "Computed final sorted sample scores. Shape: {:?}",
+            sorted_final_sample_scores.dim()
+        );
+        info!(
+            "Computed final sorted SNP loadings. Shape: {:?}",
+            sorted_final_snp_loadings.dim()
+        );
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         {
@@ -1956,18 +2368,30 @@ impl EigenSNPCoreAlgorithm {
                     // Notes on final scores/loadings for this pass can be added here.
                     // For instance, orthogonality of final_sample_scores and final_snp_loadings.
                     if !sorted_final_sample_scores.is_empty() {
-                        let final_scores_ortho = compute_orthogonality_error_f32(&sorted_final_sample_scores.view());
-                        pdc.notes.push_str(&format!(" ;FinalScoresOrthoErr_this_pass: {:?}", final_scores_ortho));
+                        let final_scores_ortho =
+                            compute_orthogonality_error_f32(&sorted_final_sample_scores.view());
+                        pdc.notes.push_str(&format!(
+                            " ;FinalScoresOrthoErr_this_pass: {:?}",
+                            final_scores_ortho
+                        ));
                     }
-                     if !sorted_final_snp_loadings.is_empty() {
-                        let final_loadings_ortho = compute_orthogonality_error_f32(&sorted_final_snp_loadings.view());
-                         pdc.notes.push_str(&format!(" ;FinalLoadingsOrthoErr_this_pass: {:?}", final_loadings_ortho));
+                    if !sorted_final_snp_loadings.is_empty() {
+                        let final_loadings_ortho =
+                            compute_orthogonality_error_f32(&sorted_final_snp_loadings.view());
+                        pdc.notes.push_str(&format!(
+                            " ;FinalLoadingsOrthoErr_this_pass: {:?}",
+                            final_loadings_ortho
+                        ));
                     }
                 }
             }
         }
 
-        Ok((sorted_final_sample_scores, sorted_final_eigenvalues, sorted_final_snp_loadings))
+        Ok((
+            sorted_final_sample_scores,
+            sorted_final_eigenvalues,
+            sorted_final_snp_loadings,
+        ))
     }
 
     /// Performs randomized SVD on a matrix A (matrix_features_by_samples, M x N).
@@ -2000,42 +2424,67 @@ impl EigenSNPCoreAlgorithm {
     #[allow(clippy::too_many_arguments)]
     fn _internal_perform_rsvd(
         matrix_features_by_samples: &ArrayView2<f32>, // Input matrix A (M features x N samples)
-        num_components_target_k: usize,              // Desired K
-        sketch_oversampling_count: usize,            // p (for L = K+p)
-        num_power_iterations: usize,                 // q
+        num_components_target_k: usize,               // Desired K
+        sketch_oversampling_count: usize,             // p (for L = K+p)
+        num_power_iterations: usize,                  // q
         random_seed: u64,
         request_u_components: bool, // True if U (left singular vectors) is needed
         request_s_components: bool, // True if S (singular values) is needed
-        request_v_components: bool,  // True if V (right singular vectors) is needed
-        #[cfg(feature = "enable-eigensnp-diagnostics")] mut diagnostics_collector_vec: Option<&mut Vec<crate::diagnostics::RsvdStepDetail>>, 
+        request_v_components: bool, // True if V (right singular vectors) is needed
+        #[cfg(feature = "enable-eigensnp-diagnostics")] mut diagnostics_collector_vec: Option<
+            &mut Vec<crate::diagnostics::RsvdStepDetail>,
+        >,
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))] _diagnostics_collector_vec: Option<()>,
-    ) -> Result<(Option<Array2<f32>>, Option<Array1<f32>>, Option<Array2<f32>>), ThreadSafeStdError> {
-        
+    ) -> Result<
+        (
+            Option<Array2<f32>>,
+            Option<Array1<f32>>,
+            Option<Array2<f32>>,
+        ),
+        ThreadSafeStdError,
+    > {
         #[cfg(feature = "enable-eigensnp-diagnostics")]
-        let push_diag_fn = |dc_vec: &mut Vec<RsvdStepDetail>, step_name: String, iteration: Option<usize>, input_dims: Option<(usize,usize)>, output_dims: Option<(usize,usize)>, matrix_to_measure: Option<&ArrayView2<f32>>, q_factor_to_measure: Option<&ArrayView2<f32>>| {
-            // dc_vec is now &mut Vec<RsvdStepDetail> directly
-            let mut detail = RsvdStepDetail::default();
-            detail.step_name = step_name;
-                if let Some(iter) = iteration { detail.notes = format!("Iteration: {}", iter); }
+        let push_diag_fn =
+            |dc_vec: &mut Vec<RsvdStepDetail>,
+             step_name: String,
+             iteration: Option<usize>,
+             input_dims: Option<(usize, usize)>,
+             output_dims: Option<(usize, usize)>,
+             matrix_to_measure: Option<&ArrayView2<f32>>,
+             q_factor_to_measure: Option<&ArrayView2<f32>>| {
+                // dc_vec is now &mut Vec<RsvdStepDetail> directly
+                let mut detail = RsvdStepDetail::default();
+                detail.step_name = step_name;
+                if let Some(iter) = iteration {
+                    detail.notes = format!("Iteration: {}", iter);
+                }
                 detail.input_matrix_dims = input_dims;
                 detail.output_matrix_dims = output_dims;
 
                 if let Some(matrix) = matrix_to_measure {
                     if !matrix.is_empty() {
                         detail.fro_norm = Some(compute_frob_norm_f32(&matrix.view()) as f64);
-                        detail.condition_number = compute_condition_number_via_svd_f32(&matrix.view());
+                        detail.condition_number =
+                            compute_condition_number_via_svd_f32(&matrix.view());
                     }
                 }
                 if let Some(q_matrix) = q_factor_to_measure {
-                     if !q_matrix.is_empty() {
-                        detail.orthogonality_error = compute_orthogonality_error_f32(&q_matrix.view());
+                    if !q_matrix.is_empty() {
+                        detail.orthogonality_error =
+                            compute_orthogonality_error_f32(&q_matrix.view());
                     }
                 }
                 dc_vec.push(detail);
-        };
+            };
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        let push_diag_fn = |_: Option<()>, _: String, _: Option<usize>, _: Option<(usize,usize)>, _: Option<(usize,usize)>, _: Option<&ArrayView2<f32>>, _: Option<&ArrayView2<f32>>| { // This signature is correct for non-diagnostic
-            // No-op for non-diagnostics build
+        let push_diag_fn = |_: Option<()>,
+                            _: String,
+                            _: Option<usize>,
+                            _: Option<(usize, usize)>,
+                            _: Option<(usize, usize)>,
+                            _: Option<&ArrayView2<f32>>,
+                            _: Option<&ArrayView2<f32>>| { // This signature is correct for non-diagnostic
+             // No-op for non-diagnostics build
         };
 
         let num_features_m = matrix_features_by_samples.nrows();
@@ -2043,22 +2492,53 @@ impl EigenSNPCoreAlgorithm {
 
         // Non-diagnostic collector_for_push_fn remains as is.
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        let collector_for_push_fn = _diagnostics_collector_vec; 
+        let collector_for_push_fn = _diagnostics_collector_vec;
 
         // Call the push_diag_fn closure, passing the appropriate collector.
         // This call needs to be updated per point 4.
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-            push_diag_fn(actual_collector, "Input_A".to_string(), None, None, Some((num_features_m, num_samples_n)), Some(&matrix_features_by_samples.view()), None);
+            push_diag_fn(
+                actual_collector,
+                "Input_A".to_string(),
+                None,
+                None,
+                Some((num_features_m, num_samples_n)),
+                Some(&matrix_features_by_samples.view()),
+                None,
+            );
         }
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        push_diag_fn(collector_for_push_fn, "Input_A".to_string(), None, None, Some((num_features_m, num_samples_n)), Some(&matrix_features_by_samples.view()), None);
+        push_diag_fn(
+            collector_for_push_fn,
+            "Input_A".to_string(),
+            None,
+            None,
+            Some((num_features_m, num_samples_n)),
+            Some(&matrix_features_by_samples.view()),
+            None,
+        );
 
         if num_features_m == 0 || num_samples_n == 0 || num_components_target_k == 0 {
-            debug!("RSVD: Input matrix empty or K=0. M={}, N={}, K={}", num_features_m, num_samples_n, num_components_target_k);
-            let u_res = if request_u_components { Some(Array2::zeros((num_features_m, 0))) } else { None };
-            let s_res = if request_s_components { Some(Array1::zeros(0)) } else { None };
-            let v_res = if request_v_components { Some(Array2::zeros((num_samples_n, 0))) } else { None };
+            debug!(
+                "RSVD: Input matrix empty or K=0. M={}, N={}, K={}",
+                num_features_m, num_samples_n, num_components_target_k
+            );
+            let u_res = if request_u_components {
+                Some(Array2::zeros((num_features_m, 0)))
+            } else {
+                None
+            };
+            let s_res = if request_s_components {
+                Some(Array1::zeros(0))
+            } else {
+                None
+            };
+            let v_res = if request_v_components {
+                Some(Array2::zeros((num_samples_n, 0)))
+            } else {
+                None
+            };
             return Ok((u_res, s_res, v_res));
         }
 
@@ -2066,147 +2546,378 @@ impl EigenSNPCoreAlgorithm {
             .min(num_features_m.min(num_samples_n));
 
         if sketch_dimension_l == 0 {
-            debug!("RSVD: Sketch dimension L=0. M={}, N={}, K={}, p={}", num_features_m, num_samples_n, num_components_target_k, sketch_oversampling_count);
-            let u_res = if request_u_components { Some(Array2::zeros((num_features_m, 0))) } else { None };
-            let s_res = if request_s_components { Some(Array1::zeros(0)) } else { None };
-            let v_res = if request_v_components { Some(Array2::zeros((num_samples_n, 0))) } else { None };
+            debug!(
+                "RSVD: Sketch dimension L=0. M={}, N={}, K={}, p={}",
+                num_features_m, num_samples_n, num_components_target_k, sketch_oversampling_count
+            );
+            let u_res = if request_u_components {
+                Some(Array2::zeros((num_features_m, 0)))
+            } else {
+                None
+            };
+            let s_res = if request_s_components {
+                Some(Array1::zeros(0))
+            } else {
+                None
+            };
+            let v_res = if request_v_components {
+                Some(Array2::zeros((num_samples_n, 0)))
+            } else {
+                None
+            };
             return Ok((u_res, s_res, v_res));
         }
         trace!(
             "RSVD internal: Target_K={}, Sketch_L={}, Input_M(features)={}, Input_N(samples)={}",
-            num_components_target_k, sketch_dimension_l, num_features_m, num_samples_n
+            num_components_target_k,
+            sketch_dimension_l,
+            num_features_m,
+            num_samples_n
         );
 
         let mut rng = ChaCha8Rng::seed_from_u64(random_seed);
-        let normal_dist = Normal::new(0.0, 1.0)
-            .map_err(|e_normal| -> ThreadSafeStdError {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("Failed to create normal distribution for RSVD: {}", e_normal),
-                ).into()
-            })?;
-        
-        // Omega: N x L
-        let random_projection_matrix_omega = Array2::from_shape_fn((num_samples_n, sketch_dimension_l), |_| {
-            normal_dist.sample(&mut rng) as f32
-        });
-        #[cfg(feature = "enable-eigensnp-diagnostics")]
-        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-            push_diag_fn(actual_collector, "Omega".to_string(), None, Some((num_samples_n, sketch_dimension_l)), Some((num_samples_n, sketch_dimension_l)), Some(&random_projection_matrix_omega.view()), None);
-        }
-        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        push_diag_fn(collector_for_push_fn, "Omega".to_string(), None, Some((num_samples_n, sketch_dimension_l)), Some((num_samples_n, sketch_dimension_l)), Some(&random_projection_matrix_omega.view()), None);
-        
-        let backend = LinAlgBackendProvider::<f32>::new();
-        
-        // Y = A * Omega (M x N) * (N x L) -> (M x L)
-        let sketch_y = Self::dot_product_mixed_precision_f32_f64acc(matrix_features_by_samples, &random_projection_matrix_omega.view())?;
-        #[cfg(feature = "enable-eigensnp-diagnostics")]
-        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-            push_diag_fn(actual_collector, "SketchY_PreQR".to_string(), None, Some((num_features_m, num_samples_n)), Some(sketch_y.dim()), Some(&sketch_y.view()), None);
-        }
-        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        push_diag_fn(collector_for_push_fn, "SketchY_PreQR".to_string(), None, Some((num_features_m, num_samples_n)), Some(sketch_y.dim()), Some(&sketch_y.view()), None);
+        let normal_dist = Normal::new(0.0, 1.0).map_err(|e_normal| -> ThreadSafeStdError {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "Failed to create normal distribution for RSVD: {}",
+                    e_normal
+                ),
+            )
+            .into()
+        })?;
 
+        // Omega: N x L
+        let random_projection_matrix_omega =
+            Array2::from_shape_fn((num_samples_n, sketch_dimension_l), |_| {
+                normal_dist.sample(&mut rng) as f32
+            });
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+            push_diag_fn(
+                actual_collector,
+                "Omega".to_string(),
+                None,
+                Some((num_samples_n, sketch_dimension_l)),
+                Some((num_samples_n, sketch_dimension_l)),
+                Some(&random_projection_matrix_omega.view()),
+                None,
+            );
+        }
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        push_diag_fn(
+            collector_for_push_fn,
+            "Omega".to_string(),
+            None,
+            Some((num_samples_n, sketch_dimension_l)),
+            Some((num_samples_n, sketch_dimension_l)),
+            Some(&random_projection_matrix_omega.view()),
+            None,
+        );
+
+        let backend = LinAlgBackendProvider::<f32>::new();
+
+        // Y = A * Omega (M x N) * (N x L) -> (M x L)
+        let sketch_y = Self::dot_product_mixed_precision_f32_f64acc(
+            matrix_features_by_samples,
+            &random_projection_matrix_omega.view(),
+        )?;
+        #[cfg(feature = "enable-eigensnp-diagnostics")]
+        if let Some(ref mut actual_collector) = diagnostics_collector_vec {
+            push_diag_fn(
+                actual_collector,
+                "SketchY_PreQR".to_string(),
+                None,
+                Some((num_features_m, num_samples_n)),
+                Some(sketch_y.dim()),
+                Some(&sketch_y.view()),
+                None,
+            );
+        }
+        #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
+        push_diag_fn(
+            collector_for_push_fn,
+            "SketchY_PreQR".to_string(),
+            None,
+            Some((num_features_m, num_samples_n)),
+            Some(sketch_y.dim()),
+            Some(&sketch_y.view()),
+            None,
+        );
 
         if sketch_y.ncols() == 0 {
             warn!("RSVD: Initial sketch Y (A*Omega) has zero columns before first QR. Target_K={}, Sketch_L={}", num_components_target_k, sketch_dimension_l);
-            let u_res = if request_u_components { Some(Array2::zeros((num_features_m, 0))) } else { None };
-            let s_res = if request_s_components { Some(Array1::zeros(0)) } else { None };
-            let v_res = if request_v_components { Some(Array2::zeros((num_samples_n, 0))) } else { None };
+            let u_res = if request_u_components {
+                Some(Array2::zeros((num_features_m, 0)))
+            } else {
+                None
+            };
+            let s_res = if request_s_components {
+                Some(Array1::zeros(0))
+            } else {
+                None
+            };
+            let v_res = if request_v_components {
+                Some(Array2::zeros((num_samples_n, 0)))
+            } else {
+                None
+            };
             return Ok((u_res, s_res, v_res));
         }
-        
+
         // Q_basis = orth(Y) (M x L_actual_y)
-        let mut q_basis_m_by_l_actual = backend.qr_q_factor(&sketch_y)
-            .map_err(|e_qr| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("QR decomposition of initial sketch Y failed in RSVD: {}", e_qr))) as ThreadSafeStdError)?;
+        let mut q_basis_m_by_l_actual = backend.qr_q_factor(&sketch_y).map_err(|e_qr| {
+            Box::new(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!(
+                    "QR decomposition of initial sketch Y failed in RSVD: {}",
+                    e_qr
+                ),
+            )) as ThreadSafeStdError
+        })?;
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-            push_diag_fn(actual_collector, "Q0_PostQR".to_string(), Some(0), Some(sketch_y.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
+            push_diag_fn(
+                actual_collector,
+                "Q0_PostQR".to_string(),
+                Some(0),
+                Some(sketch_y.dim()),
+                Some(q_basis_m_by_l_actual.dim()),
+                None,
+                Some(&q_basis_m_by_l_actual.view()),
+            );
         }
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        push_diag_fn(collector_for_push_fn, "Q0_PostQR".to_string(), Some(0), Some(sketch_y.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
-        
+        push_diag_fn(
+            collector_for_push_fn,
+            "Q0_PostQR".to_string(),
+            Some(0),
+            Some(sketch_y.dim()),
+            Some(q_basis_m_by_l_actual.dim()),
+            None,
+            Some(&q_basis_m_by_l_actual.view()),
+        );
+
         // Power iterations
         for iter_idx in 0..num_power_iterations {
-            if q_basis_m_by_l_actual.ncols() == 0 { 
-                trace!("RSVD Power Iteration {}: Q_basis became empty, breaking.", iter_idx + 1);
-                break; 
+            if q_basis_m_by_l_actual.ncols() == 0 {
+                trace!(
+                    "RSVD Power Iteration {}: Q_basis became empty, breaking.",
+                    iter_idx + 1
+                );
+                break;
             }
-            trace!("RSVD Power Iteration {}/{}", iter_idx + 1, num_power_iterations);
-            
+            trace!(
+                "RSVD Power Iteration {}/{}",
+                iter_idx + 1,
+                num_power_iterations
+            );
+
             // Q_tilde_candidate = A.T * Q_basis (N x M) * (M x L_actual) -> (N x L_actual)
-            let q_tilde_candidate = Self::dot_product_at_b_mixed_precision(matrix_features_by_samples, &q_basis_m_by_l_actual.view())?;
+            let q_tilde_candidate = Self::dot_product_at_b_mixed_precision(
+                matrix_features_by_samples,
+                &q_basis_m_by_l_actual.view(),
+            )?;
             #[cfg(feature = "enable-eigensnp-diagnostics")]
             if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-                push_diag_fn(actual_collector, format!("PowerIter{}_Ytilde_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_m_by_l_actual.dim()), Some(q_tilde_candidate.dim()), Some(&q_tilde_candidate.view()), None);
+                push_diag_fn(
+                    actual_collector,
+                    format!("PowerIter{}_Ytilde_PreQR", iter_idx + 1),
+                    Some(iter_idx + 1),
+                    Some(q_basis_m_by_l_actual.dim()),
+                    Some(q_tilde_candidate.dim()),
+                    Some(&q_tilde_candidate.view()),
+                    None,
+                );
             }
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Ytilde_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_m_by_l_actual.dim()), Some(q_tilde_candidate.dim()), Some(&q_tilde_candidate.view()), None);
+            push_diag_fn(
+                collector_for_push_fn,
+                format!("PowerIter{}_Ytilde_PreQR", iter_idx + 1),
+                Some(iter_idx + 1),
+                Some(q_basis_m_by_l_actual.dim()),
+                Some(q_tilde_candidate.dim()),
+                Some(&q_tilde_candidate.view()),
+                None,
+            );
 
-            if q_tilde_candidate.ncols() == 0 { 
-                q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(),0)); 
-                trace!("RSVD Power Iteration {}: Q_tilde_candidate became empty.", iter_idx + 1);
-                break; 
+            if q_tilde_candidate.ncols() == 0 {
+                q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(), 0));
+                trace!(
+                    "RSVD Power Iteration {}: Q_tilde_candidate became empty.",
+                    iter_idx + 1
+                );
+                break;
             }
             // Q_tilde = orth(Q_tilde_candidate) (N x L_actual_tilde)
-            let q_tilde_n_by_l_actual = backend.qr_q_factor(&q_tilde_candidate)
-                .map_err(|e_qr| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("QR for Q_tilde in power iteration {} failed: {}", iter_idx + 1, e_qr))) as ThreadSafeStdError)?;
+            let q_tilde_n_by_l_actual =
+                backend.qr_q_factor(&q_tilde_candidate).map_err(|e_qr| {
+                    Box::new(std::io::Error::new(
+                        std::io::ErrorKind::Other,
+                        format!(
+                            "QR for Q_tilde in power iteration {} failed: {}",
+                            iter_idx + 1,
+                            e_qr
+                        ),
+                    )) as ThreadSafeStdError
+                })?;
             #[cfg(feature = "enable-eigensnp-diagnostics")]
             if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-                push_diag_fn(actual_collector, format!("PowerIter{}_Qtilde_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_candidate.dim()), Some(q_tilde_n_by_l_actual.dim()), None, Some(&q_tilde_n_by_l_actual.view()));
+                push_diag_fn(
+                    actual_collector,
+                    format!("PowerIter{}_Qtilde_PostQR", iter_idx + 1),
+                    Some(iter_idx + 1),
+                    Some(q_tilde_candidate.dim()),
+                    Some(q_tilde_n_by_l_actual.dim()),
+                    None,
+                    Some(&q_tilde_n_by_l_actual.view()),
+                );
             }
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Qtilde_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_candidate.dim()), Some(q_tilde_n_by_l_actual.dim()), None, Some(&q_tilde_n_by_l_actual.view()));
+            push_diag_fn(
+                collector_for_push_fn,
+                format!("PowerIter{}_Qtilde_PostQR", iter_idx + 1),
+                Some(iter_idx + 1),
+                Some(q_tilde_candidate.dim()),
+                Some(q_tilde_n_by_l_actual.dim()),
+                None,
+                Some(&q_tilde_n_by_l_actual.view()),
+            );
 
             if q_tilde_n_by_l_actual.ncols() == 0 {
-                q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(),0));
-                trace!("RSVD Power Iteration {}: Q_tilde became empty after QR.", iter_idx + 1);
+                q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(), 0));
+                trace!(
+                    "RSVD Power Iteration {}: Q_tilde became empty after QR.",
+                    iter_idx + 1
+                );
                 break;
             }
 
             // Q_basis_candidate = A * Q_tilde (M x N) * (N x L_actual_tilde) -> (M x L_actual_tilde)
-            let q_basis_candidate_next = Self::dot_product_mixed_precision_f32_f64acc(matrix_features_by_samples, &q_tilde_n_by_l_actual.view())?;
+            let q_basis_candidate_next = Self::dot_product_mixed_precision_f32_f64acc(
+                matrix_features_by_samples,
+                &q_tilde_n_by_l_actual.view(),
+            )?;
             #[cfg(feature = "enable-eigensnp-diagnostics")]
             if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-                push_diag_fn(actual_collector, format!("PowerIter{}_Ynext_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_n_by_l_actual.dim()), Some(q_basis_candidate_next.dim()), Some(&q_basis_candidate_next.view()), None);
+                push_diag_fn(
+                    actual_collector,
+                    format!("PowerIter{}_Ynext_PreQR", iter_idx + 1),
+                    Some(iter_idx + 1),
+                    Some(q_tilde_n_by_l_actual.dim()),
+                    Some(q_basis_candidate_next.dim()),
+                    Some(&q_basis_candidate_next.view()),
+                    None,
+                );
             }
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Ynext_PreQR", iter_idx+1), Some(iter_idx+1), Some(q_tilde_n_by_l_actual.dim()), Some(q_basis_candidate_next.dim()), Some(&q_basis_candidate_next.view()), None);
+            push_diag_fn(
+                collector_for_push_fn,
+                format!("PowerIter{}_Ynext_PreQR", iter_idx + 1),
+                Some(iter_idx + 1),
+                Some(q_tilde_n_by_l_actual.dim()),
+                Some(q_basis_candidate_next.dim()),
+                Some(&q_basis_candidate_next.view()),
+                None,
+            );
 
             if q_basis_candidate_next.ncols() == 0 {
-                 q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(),0));
-                 trace!("RSVD Power Iteration {}: Q_basis_candidate_next became empty.", iter_idx + 1);
-                 break;
+                q_basis_m_by_l_actual = Array2::zeros((q_basis_m_by_l_actual.nrows(), 0));
+                trace!(
+                    "RSVD Power Iteration {}: Q_basis_candidate_next became empty.",
+                    iter_idx + 1
+                );
+                break;
             }
             // Q_basis = orth(Q_basis_candidate_next) (M x L_actual_final_iter)
-            q_basis_m_by_l_actual = backend.qr_q_factor(&q_basis_candidate_next)
-                .map_err(|e_qr| Box::new(std::io::Error::new(std::io::ErrorKind::Other, format!("QR for Q_basis in power iteration {} failed: {}", iter_idx + 1, e_qr))) as ThreadSafeStdError)?;
+            q_basis_m_by_l_actual =
+                backend
+                    .qr_q_factor(&q_basis_candidate_next)
+                    .map_err(|e_qr| {
+                        Box::new(std::io::Error::new(
+                            std::io::ErrorKind::Other,
+                            format!(
+                                "QR for Q_basis in power iteration {} failed: {}",
+                                iter_idx + 1,
+                                e_qr
+                            ),
+                        )) as ThreadSafeStdError
+                    })?;
             #[cfg(feature = "enable-eigensnp-diagnostics")]
             if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-                push_diag_fn(actual_collector, format!("PowerIter{}_Qnext_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_candidate_next.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
+                push_diag_fn(
+                    actual_collector,
+                    format!("PowerIter{}_Qnext_PostQR", iter_idx + 1),
+                    Some(iter_idx + 1),
+                    Some(q_basis_candidate_next.dim()),
+                    Some(q_basis_m_by_l_actual.dim()),
+                    None,
+                    Some(&q_basis_m_by_l_actual.view()),
+                );
             }
             #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-            push_diag_fn(collector_for_push_fn, format!("PowerIter{}_Qnext_PostQR", iter_idx+1), Some(iter_idx+1), Some(q_basis_candidate_next.dim()), Some(q_basis_m_by_l_actual.dim()), None, Some(&q_basis_m_by_l_actual.view()));
+            push_diag_fn(
+                collector_for_push_fn,
+                format!("PowerIter{}_Qnext_PostQR", iter_idx + 1),
+                Some(iter_idx + 1),
+                Some(q_basis_candidate_next.dim()),
+                Some(q_basis_m_by_l_actual.dim()),
+                None,
+                Some(&q_basis_m_by_l_actual.view()),
+            );
         }
-        
+
         if q_basis_m_by_l_actual.ncols() == 0 {
-            warn!("RSVD: Refined Q_basis has zero columns after power iterations. Target_K={}", num_components_target_k);
-            let u_res = if request_u_components { Some(Array2::zeros((num_features_m, 0))) } else { None };
-            let s_res = if request_s_components { Some(Array1::zeros(0)) } else { None };
-            let v_res = if request_v_components { Some(Array2::zeros((num_samples_n, 0))) } else { None };
+            warn!(
+                "RSVD: Refined Q_basis has zero columns after power iterations. Target_K={}",
+                num_components_target_k
+            );
+            let u_res = if request_u_components {
+                Some(Array2::zeros((num_features_m, 0)))
+            } else {
+                None
+            };
+            let s_res = if request_s_components {
+                Some(Array1::zeros(0))
+            } else {
+                None
+            };
+            let v_res = if request_v_components {
+                Some(Array2::zeros((num_samples_n, 0)))
+            } else {
+                None
+            };
             return Ok((u_res, s_res, v_res));
         }
-        
+
         // B = Q_basis.T * A (L_actual x M) * (M x N) -> (L_actual x N)
-        let projected_b_l_actual_by_n = Self::dot_product_at_b_mixed_precision(&q_basis_m_by_l_actual.view(), matrix_features_by_samples)?;
+        let projected_b_l_actual_by_n = Self::dot_product_at_b_mixed_precision(
+            &q_basis_m_by_l_actual.view(),
+            matrix_features_by_samples,
+        )?;
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-            push_diag_fn(actual_collector, "ProjectedB_PreSVD".to_string(), None, Some(q_basis_m_by_l_actual.dim()), Some(projected_b_l_actual_by_n.dim()), Some(&projected_b_l_actual_by_n.view()), None);
+            push_diag_fn(
+                actual_collector,
+                "ProjectedB_PreSVD".to_string(),
+                None,
+                Some(q_basis_m_by_l_actual.dim()),
+                Some(projected_b_l_actual_by_n.dim()),
+                Some(&projected_b_l_actual_by_n.view()),
+                None,
+            );
         }
         #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-        push_diag_fn(collector_for_push_fn, "ProjectedB_PreSVD".to_string(), None, Some(q_basis_m_by_l_actual.dim()), Some(projected_b_l_actual_by_n.dim()), Some(&projected_b_l_actual_by_n.view()), None);
-        
+        push_diag_fn(
+            collector_for_push_fn,
+            "ProjectedB_PreSVD".to_string(),
+            None,
+            Some(q_basis_m_by_l_actual.dim()),
+            Some(projected_b_l_actual_by_n.dim()),
+            Some(&projected_b_l_actual_by_n.view()),
+            None,
+        );
+
         // SVD of B: B = U_B * S_B * V_B.T
         // U_B is L_actual x rank_b
         // S_B is rank_b
@@ -2216,24 +2927,39 @@ impl EigenSNPCoreAlgorithm {
 
         use crate::linalg_backends::SVDOutput; // Ensure this type is available or use its definition
 
-        let svd_result_b = backend.svd_into(projected_b_l_actual_by_n.clone().into_owned(), compute_u_for_b, compute_v_for_b);
-    
+        let svd_result_b = backend.svd_into(
+            projected_b_l_actual_by_n.clone().into_owned(),
+            compute_u_for_b,
+            compute_v_for_b,
+        );
+
         let svd_output_b = match svd_result_b {
             Ok(output) => output,
             Err(e_svd) => {
                 // Check if the error message string contains typical ndarray-linalg error indicators
                 // This is a bit heuristic as we don't have the exact error type here easily.
                 let error_string = format!("{}", e_svd);
-                if error_string.contains("LinalgError") || error_string.contains("NonConverged") || error_string.contains("IllegalParameter") {
+                if error_string.contains("LinalgError")
+                    || error_string.contains("NonConverged")
+                    || error_string.contains("IllegalParameter")
+                {
                     warn!(
                         "RSVD: SVD of projected matrix B failed (likely due to low rank or numerical issues): {}. Proceeding with 0 components from this SVD.",
                         e_svd
                     );
                     // Create an empty SvdOutput structure
                     SVDOutput {
-                        u: if compute_u_for_b { Some(Array2::zeros((q_basis_m_by_l_actual.ncols(), 0))) } else { None },
+                        u: if compute_u_for_b {
+                            Some(Array2::zeros((q_basis_m_by_l_actual.ncols(), 0)))
+                        } else {
+                            None
+                        },
                         s: Array1::<f32>::zeros(0), // Assuming f32 context, A::Real would be f32
-                        vt: if compute_v_for_b { Some(Array2::zeros((0, matrix_features_by_samples.ncols()))) } else { None },
+                        vt: if compute_v_for_b {
+                            Some(Array2::zeros((0, matrix_features_by_samples.ncols())))
+                        } else {
+                            None
+                        },
                     }
                 } else {
                     // If it's some other error, propagate it
@@ -2247,29 +2973,42 @@ impl EigenSNPCoreAlgorithm {
 
         #[cfg(feature = "enable-eigensnp-diagnostics")]
         {
-            if let Some(ref mut dc_vec) = diagnostics_collector_vec { // Changed to use diagnostics_collector_vec and ref mut
+            if let Some(ref mut dc_vec) = diagnostics_collector_vec {
+                // Changed to use diagnostics_collector_vec and ref mut
                 // dc_vec is now &mut Vec<RsvdStepDetail>
                 let mut detail_svd = RsvdStepDetail::default();
                 detail_svd.step_name = "SVD_of_B".to_string();
-                if let Some(u_b) = svd_output_b.u.as_ref() { 
-                    detail_svd.notes.push_str(&format!("U_B dims: {:?}; ", u_b.dim()));
+                if let Some(u_b) = svd_output_b.u.as_ref() {
+                    detail_svd
+                        .notes
+                        .push_str(&format!("U_B dims: {:?}; ", u_b.dim()));
                     // Could add more detailed metrics for U_B if needed
                 }
                 detail_svd.num_singular_values = Some(svd_output_b.s.len());
-                detail_svd.singular_values_sample = sample_singular_values(&svd_output_b.s.view(), 10).map(|v_f32| v_f32.iter().map(|&x| x as f64).collect()); // Store as f64
+                detail_svd.singular_values_sample =
+                    sample_singular_values(&svd_output_b.s.view(), 10)
+                        .map(|v_f32| v_f32.iter().map(|&x| x as f64).collect()); // Store as f64
                 if let Some(vt_b) = svd_output_b.vt.as_ref() {
-                     detail_svd.notes.push_str(&format!("Vt_B dims: {:?}; ", vt_b.dim()));
+                    detail_svd
+                        .notes
+                        .push_str(&format!("Vt_B dims: {:?}; ", vt_b.dim()));
                 }
 
                 // SVD Reconstruction Error for B = U_B S_B Vt_B
                 // Need original B (projected_b_l_actual_by_n), U_B, S_B, Vt_B
-                if let (Some(u_b_val), Some(vt_b_val)) = (svd_output_b.u.as_ref(), svd_output_b.vt.as_ref()) {
-                     if !projected_b_l_actual_by_n.is_empty() && !u_b_val.is_empty() && !svd_output_b.s.is_empty() && !vt_b_val.is_empty() {
+                if let (Some(u_b_val), Some(vt_b_val)) =
+                    (svd_output_b.u.as_ref(), svd_output_b.vt.as_ref())
+                {
+                    if !projected_b_l_actual_by_n.is_empty()
+                        && !u_b_val.is_empty()
+                        && !svd_output_b.s.is_empty()
+                        && !vt_b_val.is_empty()
+                    {
                         let reconstruction_error = compute_svd_reconstruction_error_f32(
                             &projected_b_l_actual_by_n.view(),
                             &u_b_val.view(),
                             &svd_output_b.s.view(),
-                            &vt_b_val.view()
+                            &vt_b_val.view(),
                         );
                         detail_svd.svd_reconstruction_error_rel = reconstruction_error;
                         // Could also compute absolute error if needed.
@@ -2278,7 +3017,7 @@ impl EigenSNPCoreAlgorithm {
                 dc_vec.push(detail_svd);
             }
         }
-        
+
         let mut u_a_approx_opt: Option<Array2<f32>> = None;
         let mut s_a_approx_opt: Option<Array1<f32>> = None;
         let mut v_a_approx_opt: Option<Array2<f32>> = None;
@@ -2291,7 +3030,7 @@ impl EigenSNPCoreAlgorithm {
             // svd_output_b.s is Array1<f32>.
             // num_k_to_return was calculated earlier and is the number of components the user wants.
             // effective_rank_b is svd_output_b.s.len(), the actual number of singular values from SVD.
-            
+
             let actual_k_to_slice = std::cmp::min(num_k_to_return, effective_rank_b);
 
             if actual_k_to_slice == 0 {
@@ -2308,16 +3047,34 @@ impl EigenSNPCoreAlgorithm {
                 if u_b_l_actual_by_rank_b.ncols() > 0 && q_basis_m_by_l_actual.ncols() > 0 {
                     // U_A = Q_basis * U_B (M x L_actual) * (L_actual x rank_b) -> M x rank_b
                     let u_a_approx_m_by_rank_b = q_basis_m_by_l_actual.dot(&u_b_l_actual_by_rank_b);
-                    let u_a_final = u_a_approx_m_by_rank_b.slice_axis(Axis(1), ndarray::Slice::from(0..num_k_to_return)).to_owned();
+                    let u_a_final = u_a_approx_m_by_rank_b
+                        .slice_axis(Axis(1), ndarray::Slice::from(0..num_k_to_return))
+                        .to_owned();
                     #[cfg(feature = "enable-eigensnp-diagnostics")]
                     if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-                        push_diag_fn(actual_collector, "Final_U_A".to_string(), None, Some(u_a_approx_m_by_rank_b.dim()), Some(u_a_final.dim()), Some(&u_a_final.view()), Some(&u_a_final.view()));
+                        push_diag_fn(
+                            actual_collector,
+                            "Final_U_A".to_string(),
+                            None,
+                            Some(u_a_approx_m_by_rank_b.dim()),
+                            Some(u_a_final.dim()),
+                            Some(&u_a_final.view()),
+                            Some(&u_a_final.view()),
+                        );
                     }
                     #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-                    push_diag_fn(collector_for_push_fn, "Final_U_A".to_string(), None, Some(u_a_approx_m_by_rank_b.dim()), Some(u_a_final.dim()), Some(&u_a_final.view()), Some(&u_a_final.view())); 
+                    push_diag_fn(
+                        collector_for_push_fn,
+                        "Final_U_A".to_string(),
+                        None,
+                        Some(u_a_approx_m_by_rank_b.dim()),
+                        Some(u_a_final.dim()),
+                        Some(&u_a_final.view()),
+                        Some(&u_a_final.view()),
+                    );
                     u_a_approx_opt = Some(u_a_final);
                 } else {
-                     u_a_approx_opt = Some(Array2::zeros((num_features_m, 0)));   
+                    u_a_approx_opt = Some(Array2::zeros((num_features_m, 0)));
                 }
             } else {
                 u_a_approx_opt = Some(Array2::zeros((num_features_m, 0)));
@@ -2326,25 +3083,44 @@ impl EigenSNPCoreAlgorithm {
 
         if request_v_components {
             if let Some(v_b_t_rank_b_by_n) = svd_output_b.vt {
-                if v_b_t_rank_b_by_n.nrows() > 0 { // effectively checks rank_b > 0
+                if v_b_t_rank_b_by_n.nrows() > 0 {
+                    // effectively checks rank_b > 0
                     // V_A = V_B. V_B is (N x rank_b). We have V_B.T (rank_b x N)
                     let v_a_approx_n_by_rank_b = v_b_t_rank_b_by_n.t().into_owned();
-                    let v_a_final = v_a_approx_n_by_rank_b.slice_axis(Axis(1), ndarray::Slice::from(0..num_k_to_return)).to_owned();
+                    let v_a_final = v_a_approx_n_by_rank_b
+                        .slice_axis(Axis(1), ndarray::Slice::from(0..num_k_to_return))
+                        .to_owned();
                     #[cfg(feature = "enable-eigensnp-diagnostics")]
                     if let Some(ref mut actual_collector) = diagnostics_collector_vec {
-                        push_diag_fn(actual_collector, "Final_V_A".to_string(), None, Some(v_a_approx_n_by_rank_b.dim()), Some(v_a_final.dim()), Some(&v_a_final.view()), Some(&v_a_final.view()));
+                        push_diag_fn(
+                            actual_collector,
+                            "Final_V_A".to_string(),
+                            None,
+                            Some(v_a_approx_n_by_rank_b.dim()),
+                            Some(v_a_final.dim()),
+                            Some(&v_a_final.view()),
+                            Some(&v_a_final.view()),
+                        );
                     }
                     #[cfg(not(feature = "enable-eigensnp-diagnostics"))]
-                    push_diag_fn(collector_for_push_fn, "Final_V_A".to_string(), None, Some(v_a_approx_n_by_rank_b.dim()), Some(v_a_final.dim()), Some(&v_a_final.view()), Some(&v_a_final.view())); 
+                    push_diag_fn(
+                        collector_for_push_fn,
+                        "Final_V_A".to_string(),
+                        None,
+                        Some(v_a_approx_n_by_rank_b.dim()),
+                        Some(v_a_final.dim()),
+                        Some(&v_a_final.view()),
+                        Some(&v_a_final.view()),
+                    );
                     v_a_approx_opt = Some(v_a_final);
                 } else {
                     v_a_approx_opt = Some(Array2::zeros((num_samples_n, 0)));
                 }
             } else {
-                 v_a_approx_opt = Some(Array2::zeros((num_samples_n, 0)));
+                v_a_approx_opt = Some(Array2::zeros((num_samples_n, 0)));
             }
         }
-        
+
         trace!(
             "RSVD internal successfully computed components. U_shape={:?}, S_len={}, V_shape={:?}",
             u_a_approx_opt.as_ref().map(|m| m.dim()),
@@ -2383,7 +3159,7 @@ impl EigenSNPCoreAlgorithm {
         if m_dim == 0 || p_common_dim_a == 0 || k_dim == 0 {
             return Ok(Array2::<f32>::zeros((m_dim, k_dim)));
         }
-        
+
         let mut result_matrix_f32 = Array2::<f32>::zeros((m_dim, k_dim));
 
         result_matrix_f32
@@ -2392,12 +3168,14 @@ impl EigenSNPCoreAlgorithm {
             .enumerate()
             .for_each(|(i_row_idx, mut output_row_view)| {
                 let a_row_i = a_matrix_view.row(i_row_idx);
-                let a_row_slice = a_row_i.to_slice().expect("Failed to slice a_row_i, data might not be contiguous or in standard layout.");
+                let a_row_slice = a_row_i.to_slice().expect(
+                    "Failed to slice a_row_i, data might not be contiguous or in standard layout.",
+                );
 
                 for j_col_idx in 0..k_dim {
                     let mut accumulator_f64: f64 = 0.0;
                     let b_column_j = b_matrix_view.column(j_col_idx); // Obtain the column view for B
-                    // b_column_slice is removed.
+                                                                      // b_column_slice is removed.
 
                     let num_simd_chunks = p_common_dim_a / LANES;
                     let mut simd_f32_partial_sum = Simd::splat(0.0f32); // Ensure f32 type for splat
@@ -2405,13 +3183,13 @@ impl EigenSNPCoreAlgorithm {
                     for chunk_idx in 0..num_simd_chunks {
                         let offset = chunk_idx * LANES;
                         let a_simd = Simd::from_slice(&a_row_slice[offset..offset + LANES]);
-                        
+
                         let mut b_temp_array = [0.0f32; LANES];
                         for lane_idx in 0..LANES {
                             b_temp_array[lane_idx] = b_column_j[offset + lane_idx];
                         }
                         let b_simd = Simd::from_array(b_temp_array);
-                        
+
                         simd_f32_partial_sum += a_simd * b_simd;
                     }
                     accumulator_f64 += simd_f32_partial_sum.reduce_sum() as f64;
@@ -2423,7 +3201,7 @@ impl EigenSNPCoreAlgorithm {
                     output_row_view[j_col_idx] = accumulator_f64 as f32;
                 }
             });
-            
+
         Ok(result_matrix_f32)
     }
 }

--- a/src/eigensnp_tests.rs
+++ b/src/eigensnp_tests.rs
@@ -3,9 +3,9 @@
 // This module is conditionally compiled via src/lib.rs
 // #[cfg(feature = "enable-eigensnp-diagnostics")]
 
-use serde::{Serialize, Deserialize}; // For TestResultRecord if it needs to be serialized later
-use std::sync::Mutex;
-use once_cell::sync::Lazy; // Using once_cell for static initialization
+use once_cell::sync::Lazy;
+use serde::{Deserialize, Serialize}; // For TestResultRecord if it needs to be serialized later
+use std::sync::Mutex; // Using once_cell for static initialization
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TestResultRecord {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,27 +1,19 @@
 #![feature(portable_simd)]
 #![doc = include_str!("../README.md")] // Crate-level documentation
 
+pub mod diagnostics;
+pub mod eigensnp;
 pub mod linalg_backends; // Consolidated module
 pub mod pca;
-pub mod eigensnp;
-pub mod diagnostics;
 
 #[cfg(feature = "enable-eigensnp-diagnostics")]
 pub mod eigensnp_tests;
-
 
 pub use pca::PCA;
 
 // Re-export key items from the eigensnp module for users of the EigenSNP functionality.
 pub use eigensnp::{
-    EigenSNPCoreAlgorithm,
-    EigenSNPCoreAlgorithmConfig,
-    EigenSNPCoreOutput,
-    LdBlockSpecification,
-    PcaReadyGenotypeAccessor,
-    PcaSnpId,
+    CondensedFeatureId, EigenSNPCoreAlgorithm, EigenSNPCoreAlgorithmConfig, EigenSNPCoreOutput,
+    LdBlockListId, LdBlockSpecification, PcaReadyGenotypeAccessor, PcaSnpId, PrincipalComponentId,
     QcSampleId,
-    LdBlockListId,
-    CondensedFeatureId,
-    PrincipalComponentId,
 };

--- a/tests/eigensnp_diagnostics_tests.rs
+++ b/tests/eigensnp_diagnostics_tests.rs
@@ -1,19 +1,19 @@
 #![cfg(feature = "enable-eigensnp-diagnostics")]
 
+use efficient_pca::diagnostics::FullPcaRunDetailedDiagnostics;
 use efficient_pca::eigensnp::{
-    EigenSNPCoreAlgorithm, EigenSNPCoreAlgorithmConfig, EigenSNPCoreOutput,
-    LdBlockSpecification, PcaReadyGenotypeAccessor, PcaSnpId, QcSampleId, ThreadSafeStdError,
-};
-use efficient_pca::diagnostics::{FullPcaRunDetailedDiagnostics}; // Removed RsvdStepDetail, PerBlockLocalBasisDiagnostics
+    EigenSNPCoreAlgorithm, EigenSNPCoreAlgorithmConfig, EigenSNPCoreOutput, LdBlockSpecification,
+    PcaReadyGenotypeAccessor, PcaSnpId, QcSampleId, ThreadSafeStdError,
+}; // Removed RsvdStepDetail, PerBlockLocalBasisDiagnostics
 
-use ndarray::{Array2}; // Removed Array1, Axis
+use ndarray::Array2; // Removed Array1, Axis
 use rand::Rng; // For genotype data generation
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use std::fs::{File}; // Removed self
-use std::io::{Write, BufReader}; // Added BufReader
-use std::path::Path;
-use serde_json; // For parsing JSON
+use serde_json;
+use std::fs::File; // Removed self
+use std::io::{BufReader, Write}; // Added BufReader
+use std::path::Path; // For parsing JSON
 
 // Attempt to import TestResultRecord and TEST_RESULTS
 // This path might need adjustment if the actual module structure is different.
@@ -21,8 +21,7 @@ use serde_json; // For parsing JSON
 // If `efficient_pca::eigensnp_tests` is not a public module, or these items are not public,
 // this will fail compilation and require adjustment in a later step.
 #[cfg(test)]
-use efficient_pca::eigensnp_tests::{TestResultRecord};
-
+use efficient_pca::eigensnp_tests::TestResultRecord;
 
 // --- Mock Genotype Data Accessor ---
 #[derive(Clone)]
@@ -62,7 +61,7 @@ impl PcaReadyGenotypeAccessor for MockGenotypeData {
 }
 
 // --- Helper Function to Run Diagnostic Test ---
-#[allow(dead_code)] 
+#[allow(dead_code)]
 fn run_diagnostic_test_with_params(
     num_snps: usize,
     num_samples: usize,
@@ -72,13 +71,14 @@ fn run_diagnostic_test_with_params(
     local_rsvd_num_power_iterations: usize, // Added this to vary it
     global_pca_num_power_iterations: usize, // Added this for completeness
     refine_pass_count: usize,
-    diagnostic_block_list_id_to_trace: Option<usize>, 
+    diagnostic_block_list_id_to_trace: Option<usize>,
     output_filename_suffix: &str,
-) -> Result<String, Box<dyn std::error::Error>> { // Returns path to output file
-    let mut rng = ChaCha8Rng::seed_from_u64(42); 
+) -> Result<String, Box<dyn std::error::Error>> {
+    // Returns path to output file
+    let mut rng = ChaCha8Rng::seed_from_u64(42);
     let genotypes = Array2::from_shape_fn((num_snps, num_samples), |_| rng.gen_range(0.0..=2.0));
     let mock_data_accessor = MockGenotypeData {
-        genotypes: genotypes.clone(), 
+        genotypes: genotypes.clone(),
         num_qc_samples: num_samples,
         num_pca_snps: num_snps,
     };
@@ -89,36 +89,41 @@ fn run_diagnostic_test_with_params(
         let mut current_snp_idx = 0;
         for i in 0..num_ld_blocks {
             let end_snp_idx = (current_snp_idx + snps_per_block).min(num_snps);
-            if current_snp_idx >= end_snp_idx && i < num_ld_blocks -1 { continue; } // Avoid empty blocks unless it's the last one potentially
-             if current_snp_idx >= num_snps { break; }
+            if current_snp_idx >= end_snp_idx && i < num_ld_blocks - 1 {
+                continue;
+            } // Avoid empty blocks unless it's the last one potentially
+            if current_snp_idx >= num_snps {
+                break;
+            }
 
+            let pca_snp_ids_in_block: Vec<PcaSnpId> =
+                (current_snp_idx..end_snp_idx).map(PcaSnpId).collect();
 
-            let pca_snp_ids_in_block: Vec<PcaSnpId> = (current_snp_idx..end_snp_idx)
-                .map(PcaSnpId)
-                .collect();
-            
             if pca_snp_ids_in_block.is_empty() && current_snp_idx < num_snps {
                 // If somehow an empty block is generated for non-last blocks, assign remaining to it if needed.
                 // This logic can be simplified if num_snps is always cleanly divisible or last block takes all.
                 // For now, just ensure non-empty if possible.
-                 if i == num_ld_blocks - 1 && current_snp_idx < num_snps {
+                if i == num_ld_blocks - 1 && current_snp_idx < num_snps {
                     ld_block_specs.push(LdBlockSpecification {
                         user_defined_block_tag: format!("block_{}", i),
                         pca_snp_ids_in_block: (current_snp_idx..num_snps).map(PcaSnpId).collect(),
                     });
-                    #[allow(unused_assignments)] { current_snp_idx = num_snps; } // all assigned
+                    #[allow(unused_assignments)]
+                    {
+                        current_snp_idx = num_snps;
+                    } // all assigned
                     break;
-                 }
-                 // else skip empty block if not the last one.
+                }
+                // else skip empty block if not the last one.
             } else if !pca_snp_ids_in_block.is_empty() {
-                 ld_block_specs.push(LdBlockSpecification {
+                ld_block_specs.push(LdBlockSpecification {
                     user_defined_block_tag: format!("block_{}", i),
                     pca_snp_ids_in_block,
                 });
             }
             current_snp_idx = end_snp_idx;
         }
-         // If after loop, not all SNPs assigned (e.g. num_ld_blocks = 0 but num_snps > 0), create one encompassing block
+        // If after loop, not all SNPs assigned (e.g. num_ld_blocks = 0 but num_snps > 0), create one encompassing block
         if num_snps > 0 && ld_block_specs.is_empty() {
             ld_block_specs.push(LdBlockSpecification {
                 user_defined_block_tag: "block_0_catch_all".to_string(),
@@ -127,29 +132,41 @@ fn run_diagnostic_test_with_params(
         }
     }
 
-
     let config = EigenSNPCoreAlgorithmConfig {
-        subset_factor_for_local_basis_learning: 0.5, 
-        min_subset_size_for_local_basis_learning: (num_samples / 2).max(10).min(num_samples), 
+        subset_factor_for_local_basis_learning: 0.5,
+        min_subset_size_for_local_basis_learning: (num_samples / 2).max(10).min(num_samples),
         max_subset_size_for_local_basis_learning: num_samples,
         components_per_ld_block,
         target_num_global_pcs,
-        global_pca_sketch_oversampling: 5.min(if target_num_global_pcs > 0 { target_num_global_pcs-1 } else {0}).max(1), // Ensure > 0 if k > 0
+        global_pca_sketch_oversampling: 5
+            .min(if target_num_global_pcs > 0 {
+                target_num_global_pcs - 1
+            } else {
+                0
+            })
+            .max(1), // Ensure > 0 if k > 0
         global_pca_num_power_iterations, // Use passed param
-        local_rsvd_sketch_oversampling: 5.min(if components_per_ld_block > 0 {components_per_ld_block-1} else {0}).max(1), // Ensure > 0 if cpb > 0
+        local_rsvd_sketch_oversampling: 5
+            .min(if components_per_ld_block > 0 {
+                components_per_ld_block - 1
+            } else {
+                0
+            })
+            .max(1), // Ensure > 0 if cpb > 0
         local_rsvd_num_power_iterations, // Use passed param
         random_seed: 123,
         snp_processing_strip_size: 500.min(num_snps).max(1),
         refine_pass_count,
-        collect_diagnostics: true, 
+        collect_diagnostics: true,
         diagnostic_block_list_id_to_trace,
     };
 
     let algorithm = EigenSNPCoreAlgorithm::new(config.clone());
-    let pca_result_tuple = algorithm.compute_pca(&mock_data_accessor, &ld_block_specs)
+    let pca_result_tuple = algorithm
+        .compute_pca(&mock_data_accessor, &ld_block_specs)
         .map_err(|e| e as Box<dyn std::error::Error>)?;
-    
-    let _pca_output: EigenSNPCoreOutput = pca_result_tuple.0; 
+
+    let _pca_output: EigenSNPCoreOutput = pca_result_tuple.0;
     let detailed_diagnostics: Option<FullPcaRunDetailedDiagnostics> = pca_result_tuple.1;
 
     let dir = Path::new("test_outputs");
@@ -158,12 +175,17 @@ fn run_diagnostic_test_with_params(
     }
     let filename = dir.join(format!(
         "diag_n{}_d{}_b{}_cpb{}_k{}_sr{}_locIter{}_globIter{}_{}.json",
-        num_samples, num_snps, ld_block_specs.len(), // Use actual number of blocks
-        components_per_ld_block, target_num_global_pcs, refine_pass_count,
-        local_rsvd_num_power_iterations, global_pca_num_power_iterations,
+        num_samples,
+        num_snps,
+        ld_block_specs.len(), // Use actual number of blocks
+        components_per_ld_block,
+        target_num_global_pcs,
+        refine_pass_count,
+        local_rsvd_num_power_iterations,
+        global_pca_num_power_iterations,
         output_filename_suffix
     ));
-    
+
     if let Some(diagnostics) = detailed_diagnostics {
         let mut file = File::create(&filename)?;
         let json_string = serde_json::to_string_pretty(&diagnostics)?;
@@ -188,7 +210,7 @@ fn diag_li0_gi2() {
     let local_rsvd_num_power_iterations = 0;
     let global_pca_num_power_iterations = 2; // Fixed for this series
     let refine_pass_count = 1; // Minimal passes
-    let diagnostic_block_id_to_trace = Some(0); 
+    let diagnostic_block_id_to_trace = Some(0);
     let suffix = "local0_global2";
 
     let mut record = TestResultRecord {
@@ -201,36 +223,51 @@ fn diag_li0_gi2() {
         success: false, // Default to false
         outcome_details: String::new(),
         notes: String::new(),
-        approx_peak_mem_mibs: None, // Not measured here
+        approx_peak_mem_mibs: None,  // Not measured here
         computation_time_secs: None, // Not measured here
     };
 
     match run_diagnostic_test_with_params(
-        num_snps, num_samples, num_ld_blocks, components_per_ld_block, target_num_global_pcs,
-        local_rsvd_num_power_iterations, global_pca_num_power_iterations, refine_pass_count,
-        diagnostic_block_id_to_trace, suffix
+        num_snps,
+        num_samples,
+        num_ld_blocks,
+        components_per_ld_block,
+        target_num_global_pcs,
+        local_rsvd_num_power_iterations,
+        global_pca_num_power_iterations,
+        refine_pass_count,
+        diagnostic_block_id_to_trace,
+        suffix,
     ) {
         Ok(filepath) => {
             record.notes = format!("Diagnostics JSON saved to: {}", filepath);
             let file = File::open(filepath).expect("Failed to open diagnostic file.");
             let reader = BufReader::new(file);
-            let diagnostics: FullPcaRunDetailedDiagnostics = serde_json::from_reader(reader)
-                .expect("Failed to parse diagnostics JSON.");
+            let diagnostics: FullPcaRunDetailedDiagnostics =
+                serde_json::from_reader(reader).expect("Failed to parse diagnostics JSON.");
 
             // Extract a key metric, e.g., condition number from a specific rSVD step
             if let Some(first_block_diag) = diagnostics.per_block_diagnostics.get(0) {
-                if let Some(rsvd_step) = first_block_diag.rsvd_stages.iter().find(|s| s.step_name == "ProjectedB_PreSVD") {
+                if let Some(rsvd_step) = first_block_diag
+                    .rsvd_stages
+                    .iter()
+                    .find(|s| s.step_name == "ProjectedB_PreSVD")
+                {
                     if let Some(cond_num) = rsvd_step.condition_number {
-                        let key_metric_info = format!("ProjectedB_PreSVD CondNum: {:.4e}", cond_num);
+                        let key_metric_info =
+                            format!("ProjectedB_PreSVD CondNum: {:.4e}", cond_num);
                         println!("{}: {}", test_name, key_metric_info);
                         record.notes.push_str(&format!(" | {}", key_metric_info));
                     }
                 }
             }
-            
+
             record.success = true;
-            record.outcome_details = format!("Ran with local_power_iter={}", local_rsvd_num_power_iterations);
-        },
+            record.outcome_details = format!(
+                "Ran with local_power_iter={}",
+                local_rsvd_num_power_iterations
+            );
+        }
         Err(e) => {
             record.success = false;
             record.outcome_details = format!("Test failed: {:?}", e);
@@ -238,13 +275,13 @@ fn diag_li0_gi2() {
             panic!("Test {} failed: {:?}", test_name, e);
         }
     }
-    
+
     // Assuming TEST_RESULTS is a globally accessible, mutable static collection
     // This part is tricky and depends on how TEST_RESULTS is implemented (e.g., using ctor, lazy_static with Mutex)
     // For now, let's simulate adding to it if it were a simple static Vec (which isn't directly possible for mutation).
     // This will likely need to be adapted based on the actual implementation of TEST_RESULTS.
     // unsafe { TEST_RESULTS.push(record) }; // This is a placeholder for actual result recording
-     println!("Test Record for {}: {:?}", test_name, record); // Print for now
+    println!("Test Record for {}: {:?}", test_name, record); // Print for now
 }
 
 // Placeholder for other tests (diag_li2_gi2, diag_li4_gi2) - to be added in subsequent steps.
@@ -258,9 +295,9 @@ fn diag_li2_gi2() {
     let components_per_ld_block = 5;
     let target_num_global_pcs = 5;
     let local_rsvd_num_power_iterations = 2; // Varied parameter
-    let global_pca_num_power_iterations = 2; 
-    let refine_pass_count = 1; 
-    let diagnostic_block_id_to_trace = Some(0); 
+    let global_pca_num_power_iterations = 2;
+    let refine_pass_count = 1;
+    let diagnostic_block_id_to_trace = Some(0);
     let suffix = "local2_global2";
 
     let mut record = TestResultRecord {
@@ -273,35 +310,50 @@ fn diag_li2_gi2() {
         success: false,
         outcome_details: String::new(),
         notes: String::new(),
-        approx_peak_mem_mibs: None, 
-        computation_time_secs: None, 
+        approx_peak_mem_mibs: None,
+        computation_time_secs: None,
     };
 
     match run_diagnostic_test_with_params(
-        num_snps, num_samples, num_ld_blocks, components_per_ld_block, target_num_global_pcs,
-        local_rsvd_num_power_iterations, global_pca_num_power_iterations, refine_pass_count,
-        diagnostic_block_id_to_trace, suffix
+        num_snps,
+        num_samples,
+        num_ld_blocks,
+        components_per_ld_block,
+        target_num_global_pcs,
+        local_rsvd_num_power_iterations,
+        global_pca_num_power_iterations,
+        refine_pass_count,
+        diagnostic_block_id_to_trace,
+        suffix,
     ) {
         Ok(filepath) => {
             record.notes = format!("Diagnostics JSON saved to: {}", filepath);
             let file = File::open(filepath).expect("Failed to open diagnostic file.");
             let reader = BufReader::new(file);
-            let diagnostics: FullPcaRunDetailedDiagnostics = serde_json::from_reader(reader)
-                .expect("Failed to parse diagnostics JSON.");
+            let diagnostics: FullPcaRunDetailedDiagnostics =
+                serde_json::from_reader(reader).expect("Failed to parse diagnostics JSON.");
 
             if let Some(first_block_diag) = diagnostics.per_block_diagnostics.get(0) {
-                if let Some(rsvd_step) = first_block_diag.rsvd_stages.iter().find(|s| s.step_name == "ProjectedB_PreSVD") {
+                if let Some(rsvd_step) = first_block_diag
+                    .rsvd_stages
+                    .iter()
+                    .find(|s| s.step_name == "ProjectedB_PreSVD")
+                {
                     if let Some(cond_num) = rsvd_step.condition_number {
-                        let key_metric_info = format!("ProjectedB_PreSVD CondNum: {:.4e}", cond_num);
+                        let key_metric_info =
+                            format!("ProjectedB_PreSVD CondNum: {:.4e}", cond_num);
                         println!("{}: {}", test_name, key_metric_info);
                         record.notes.push_str(&format!(" | {}", key_metric_info));
                     }
                 }
             }
-            
+
             record.success = true;
-            record.outcome_details = format!("Ran with local_power_iter={}", local_rsvd_num_power_iterations);
-        },
+            record.outcome_details = format!(
+                "Ran with local_power_iter={}",
+                local_rsvd_num_power_iterations
+            );
+        }
         Err(e) => {
             record.success = false;
             record.outcome_details = format!("Test failed: {:?}", e);
@@ -309,7 +361,7 @@ fn diag_li2_gi2() {
             panic!("Test {} failed: {:?}", test_name, e);
         }
     }
-     println!("Test Record for {}: {:?}", test_name, record);
+    println!("Test Record for {}: {:?}", test_name, record);
 }
 
 #[test]
@@ -341,29 +393,44 @@ fn diag_li4_gi2() {
     };
 
     match run_diagnostic_test_with_params(
-        num_snps, num_samples, num_ld_blocks, components_per_ld_block, target_num_global_pcs,
-        local_rsvd_num_power_iterations, global_pca_num_power_iterations, refine_pass_count,
-        diagnostic_block_id_to_trace, suffix
+        num_snps,
+        num_samples,
+        num_ld_blocks,
+        components_per_ld_block,
+        target_num_global_pcs,
+        local_rsvd_num_power_iterations,
+        global_pca_num_power_iterations,
+        refine_pass_count,
+        diagnostic_block_id_to_trace,
+        suffix,
     ) {
         Ok(filepath) => {
             record.notes = format!("Diagnostics JSON saved to: {}", filepath);
             let file = File::open(filepath).expect("Failed to open diagnostic file.");
             let reader = BufReader::new(file);
-            let diagnostics: FullPcaRunDetailedDiagnostics = serde_json::from_reader(reader)
-                .expect("Failed to parse diagnostics JSON.");
+            let diagnostics: FullPcaRunDetailedDiagnostics =
+                serde_json::from_reader(reader).expect("Failed to parse diagnostics JSON.");
 
             if let Some(first_block_diag) = diagnostics.per_block_diagnostics.get(0) {
-                if let Some(rsvd_step) = first_block_diag.rsvd_stages.iter().find(|s| s.step_name == "ProjectedB_PreSVD") {
+                if let Some(rsvd_step) = first_block_diag
+                    .rsvd_stages
+                    .iter()
+                    .find(|s| s.step_name == "ProjectedB_PreSVD")
+                {
                     if let Some(cond_num) = rsvd_step.condition_number {
-                        let key_metric_info = format!("ProjectedB_PreSVD CondNum: {:.4e}", cond_num);
+                        let key_metric_info =
+                            format!("ProjectedB_PreSVD CondNum: {:.4e}", cond_num);
                         println!("{}: {}", test_name, key_metric_info);
                         record.notes.push_str(&format!(" | {}", key_metric_info));
                     }
                 }
             }
             record.success = true;
-            record.outcome_details = format!("Ran with local_power_iter={}", local_rsvd_num_power_iterations);
-        },
+            record.outcome_details = format!(
+                "Ran with local_power_iter={}",
+                local_rsvd_num_power_iterations
+            );
+        }
         Err(e) => {
             record.success = false;
             record.outcome_details = format!("Test failed: {:?}", e);
@@ -373,7 +440,6 @@ fn diag_li4_gi2() {
     }
     println!("Test Record for {}: {:?}", test_name, record);
 }
-
 
 // Original placeholder, can be removed now or kept if other manual tests are needed.
 #[test]

--- a/tests/pca_tests.rs
+++ b/tests/pca_tests.rs
@@ -10,9 +10,9 @@ use linfa::prelude::*;
 use linfa_reduction::Pca as LinfaPcaModel; // The PCA implementation from Linfa, aliased
 use ndarray_linalg::{Eigh, QR, UPLO};
 
-use rand_chacha::ChaCha8Rng;
 use rand::Rng;
-use rand::SeedableRng;  // The trait that provides .seed_from_u64()
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng; // The trait that provides .seed_from_u64()
 
 fn generate_random_data(n_samples: usize, n_features: usize, seed: u64) -> Array2<f64> {
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -40,66 +40,102 @@ mod genome_tests {
         position: i64,
         genotypes: Vec<Option<Vec<u8>>>,
     }
-    
+
     #[test]
     fn test_genomic_pca_with_haplotypes() {
         println!("Testing PCA with haplotype data similar to genomic application");
-        
+
         // Set up parameters to match real usage
         let n_samples = 44; // 44 samples = 88 haplotypes
         let n_variants = 10000;
         let n_components = 10;
-        
+
         // Generate synthetic variants
         let mut variants = Vec::with_capacity(n_variants);
-        
+
         // Create variants with different allele frequencies
         // Some variants will be common, some rare
         for i in 0..n_variants {
             let position = 1000 + i as i64 * 100;
             let mut genotypes = Vec::with_capacity(n_samples);
-            
+
             // Create some extremely rare variants
             let is_extreme_rare = i < 100; // First 100 variants are extremely rare
-            
+
             for sample_idx in 0..n_samples {
                 let pop_group = sample_idx % 4;
-                
+
                 let base_prob = if is_extreme_rare {
                     // For extremely rare variants, only a single sample in a single population has it
-                    if sample_idx == (i % n_samples) && pop_group == 0 { 0.5 } else { 0.0 }
+                    if sample_idx == (i % n_samples) && pop_group == 0 {
+                        0.5
+                    } else {
+                        0.0
+                    }
                 } else {
                     // Structure for other variants
                     match i % 10 {
-                        0..=1 => if pop_group == 0 { 0.4 } else { 0.05 },
-                        2..=3 => if pop_group == 1 { 0.3 } else { 0.02 },
-                        4..=6 => if pop_group == 2 { 0.5 } else { 0.08 },
-                        _ => if pop_group == 3 { 0.3 } else { 0.02 },
+                        0..=1 => {
+                            if pop_group == 0 {
+                                0.4
+                            } else {
+                                0.05
+                            }
+                        }
+                        2..=3 => {
+                            if pop_group == 1 {
+                                0.3
+                            } else {
+                                0.02
+                            }
+                        }
+                        4..=6 => {
+                            if pop_group == 2 {
+                                0.5
+                            } else {
+                                0.08
+                            }
+                        }
+                        _ => {
+                            if pop_group == 3 {
+                                0.3
+                            } else {
+                                0.02
+                            }
+                        }
                     }
                 };
-                
+
                 // Create haplotypes
-                let left_allele = if rand::random::<f64>() < base_prob { 1u8 } else { 0u8 };
-                let right_allele = if rand::random::<f64>() < base_prob { 1u8 } else { 0u8 };
-                
+                let left_allele = if rand::random::<f64>() < base_prob {
+                    1u8
+                } else {
+                    0u8
+                };
+                let right_allele = if rand::random::<f64>() < base_prob {
+                    1u8
+                } else {
+                    0u8
+                };
+
                 genotypes.push(Some(vec![left_allele, right_allele]));
             }
-            
+
             variants.push(Variant {
                 position,
                 genotypes,
             });
         }
-        
+
         // Construct data matrix
         let n_haplotypes = n_samples * 2;
         let mut data_matrix = Array2::<f64>::zeros((n_haplotypes, n_variants));
         let mut positions = Vec::with_capacity(n_variants);
-        
+
         // Fill data matrix
         for (valid_idx, variant) in variants.iter().enumerate() {
             positions.push(variant.position);
-            
+
             // Add each haplotype's data
             for (sample_idx, genotypes_opt) in variant.genotypes.iter().enumerate() {
                 if let Some(genotypes) = genotypes_opt {
@@ -107,7 +143,7 @@ mod genome_tests {
                         // Left haplotype
                         let left_idx = sample_idx * 2;
                         data_matrix[[left_idx, valid_idx]] = genotypes[0] as f64;
-                        
+
                         // Right haplotype
                         let right_idx = sample_idx * 2 + 1;
                         data_matrix[[right_idx, valid_idx]] = genotypes[1] as f64;
@@ -115,16 +151,22 @@ mod genome_tests {
                 }
             }
         }
-        
+
         // Print matrix stats
         let (rows, cols) = data_matrix.dim();
-        println!("Data matrix: {} rows (haplotypes) x {} columns (variants)", rows, cols);
-        
+        println!(
+            "Data matrix: {} rows (haplotypes) x {} columns (variants)",
+            rows, cols
+        );
+
         // Check data matrix properties
         let zeros_count = data_matrix.iter().filter(|&&x| x == 0.0).count();
         let ones_count = data_matrix.iter().filter(|&&x| x == 1.0).count();
-        println!("Matrix contains {} zeros and {} ones", zeros_count, ones_count);
-        
+        println!(
+            "Matrix contains {} zeros and {} ones",
+            zeros_count, ones_count
+        );
+
         // Check first few columns for variance
         for c in 0..5 {
             let col = data_matrix.slice(s![.., c]);
@@ -134,31 +176,35 @@ mod genome_tests {
             let var = sum_sq / col.len() as f64;
             println!("Column {} variance: {:.6}", c, var);
         }
-        
+
         // Run PCA
         let mut pca = PCA::new();
-        
+
         match pca.rfit(
             data_matrix.clone(), // data_matrix is consumed by rfit
             n_components,
-            5, // oversampling parameter
+            5,        // oversampling parameter
             Some(42), // seed
-            None, // no variance tolerance
+            None,     // no variance tolerance
         ) {
-            Ok(transformed) => { // rfit now returns the transformed principal components directly
+            Ok(transformed) => {
+                // rfit now returns the transformed principal components directly
                 println!("PCA rfit computation successful, transformed PCs obtained.");
-                
+
                 // The `transformed` variable now holds the PC coordinates.
                 // The subsequent explicit call to pca.transform for this data is no longer needed.
-                
+
                 // Check for NaN values
                 let nan_count_unfiltered = transformed.iter().filter(|&&x| x.is_nan()).count();
                 let total_values = transformed.nrows() * transformed.ncols();
-                
-                println!("NaN check: {}/{} values are NaN ({:.2}%)", 
-                         nan_count_unfiltered, total_values, 
-                         100.0 * nan_count_unfiltered as f64 / total_values as f64);
-                
+
+                println!(
+                    "NaN check: {}/{} values are NaN ({:.2}%)",
+                    nan_count_unfiltered,
+                    total_values,
+                    100.0 * nan_count_unfiltered as f64 / total_values as f64
+                );
+
                 // Print first few PC values for inspection
                 println!("First 3 rows of PC values:");
                 // we don't panic if less than 3 rows or less than n_components are available
@@ -170,36 +216,38 @@ mod genome_tests {
                     println!();
                 }
 
-                
                 // Try the process with filtering rare variants
                 println!("\nNow testing with filtered rare variants:");
                 let mut filtered_columns = Vec::new();
-                
+
                 // Identify columns with reasonable MAF
                 for c in 0..cols {
                     let col = data_matrix.slice(s![.., c]);
                     let sum: f64 = col.iter().sum();
                     let freq = sum / col.len() as f64;
-                    
+
                     // Keep only variants with MAF between 5% and 95%
                     if freq >= 0.05 && freq <= 0.95 {
                         filtered_columns.push(c);
                     }
                 }
-                
-                println!("After filtering: {}/{} variants remain", 
-                         filtered_columns.len(), cols);
-                
+
+                println!(
+                    "After filtering: {}/{} variants remain",
+                    filtered_columns.len(),
+                    cols
+                );
+
                 if !filtered_columns.is_empty() {
                     let mut filtered_matrix = Array2::<f64>::zeros((rows, filtered_columns.len()));
-                    
+
                     // Copy selected columns to new matrix
                     for (new_c, &old_c) in filtered_columns.iter().enumerate() {
                         for r in 0..rows {
                             filtered_matrix[[r, new_c]] = data_matrix[[r, old_c]];
                         }
                     }
-                    
+
                     // Run PCA on filtered data
                     let mut pca_filtered = PCA::new();
                     match pca_filtered.rfit(
@@ -209,25 +257,32 @@ mod genome_tests {
                         Some(42),
                         None,
                     ) {
-                        Ok(transformed_filtered) => { // rfit now returns transformed PCs
+                        Ok(transformed_filtered) => {
+                            // rfit now returns transformed PCs
                             // let transformed_filtered = pca_filtered.transform(filtered_matrix).unwrap(); // This is now redundant
-                            let nan_count_filtered = transformed_filtered.iter().filter(|&&x| x.is_nan()).count();
-                            println!("Filtered PCA NaN check: {}/{} values are NaN", 
-                                    nan_count_filtered, transformed_filtered.len());
-                            
+                            let nan_count_filtered =
+                                transformed_filtered.iter().filter(|&&x| x.is_nan()).count();
+                            println!(
+                                "Filtered PCA NaN check: {}/{} values are NaN",
+                                nan_count_filtered,
+                                transformed_filtered.len()
+                            );
+
                             // Print the first 3 rows of filtered PC values to demonstrate they are valid
                             println!("First 3 rows of FILTERED PC values:");
-                                // we don't panic if less than 3 rows or less than n_components are available
+                            // we don't panic if less than 3 rows or less than n_components are available
                             for i in 0..std::cmp::min(3, transformed_filtered.nrows()) {
                                 print!("Row {}: ", i);
-                                for j in 0..std::cmp::min(n_components, transformed_filtered.ncols()) {
+                                for j in
+                                    0..std::cmp::min(n_components, transformed_filtered.ncols())
+                                {
                                     print!("{:.6} ", transformed_filtered[[i, j]]);
                                 }
                                 println!();
                             }
-                            
+
                             assert_eq!(nan_count_filtered, 0, "Filtered PCA produced NaN values");
-                        },
+                        }
                         Err(e) => {
                             panic!("Filtered PCA computation failed: {}", e);
                         }
@@ -238,8 +293,10 @@ mod genome_tests {
                 // With extremely rare variants, covariance matrix could have an
                 // issue where the ratio between largest and smallest eigenvalues becomes extremely large.
                 // We divide by the square root of eigenvalues
-                println!("Unfiltered PCA may produce NaN values: {} NaNs", {nan_count_unfiltered});
-            },
+                println!("Unfiltered PCA may produce NaN values: {} NaNs", {
+                    nan_count_unfiltered
+                });
+            }
             Err(e) => {
                 panic!("PCA computation failed: {}", e);
             }
@@ -291,7 +348,10 @@ mod genome_tests {
         // rfit consumes the input data matrix.
         let transformed = pca.rfit(data, n_components, n_oversamples, seed, None)?;
         let pca_rfit_duration = start_pca_rfit.elapsed();
-        println!("Randomized PCA rfit (which now includes transformation) completed in {:.2?}", pca_rfit_duration);
+        println!(
+            "Randomized PCA rfit (which now includes transformation) completed in {:.2?}",
+            pca_rfit_duration
+        );
 
         // Basic dimensional checks
         assert_eq!(
@@ -516,7 +576,8 @@ mod genome_tests {
         let mut rust_pca_rfit = PCA::new();
         // rfit consumes data and returns the transformed PCs.
         // Since `data` is used for both fit and rfit tests, we must clone it for rfit.
-        let rust_transformed_rfit = rust_pca_rfit.rfit(data.clone(), n_components, 5, Some(42_u64), None)?;
+        let rust_transformed_rfit =
+            rust_pca_rfit.rfit(data.clone(), n_components, 5, Some(42_u64), None)?;
 
         println!("\nCorrelations for rfit method:");
         println!("Component | Correlation | Required | Status");
@@ -648,9 +709,9 @@ mod genome_tests {
 mod model_persistence_tests {
     use super::*;
     use ndarray::{array, Array1, Array2};
-    use tempfile::NamedTempFile;
     use std::error::Error;
-    use std::f64; // For f64::NAN
+    use std::f64;
+    use tempfile::NamedTempFile; // For f64::NAN
 
     const COMPARISON_TOLERANCE: f64 = 1e-12; // Tolerance for float comparisons
 
@@ -723,10 +784,23 @@ mod model_persistence_tests {
         pca_original.fit(data.clone(), None)?; // Fit with exact PCA
 
         // Pre-save assertions
-        assert!(pca_original.rotation().is_some(), "Original (exact) model rotation should be Some");
-        assert!(pca_original.mean().is_some(), "Original (exact) model mean should be Some");
-        assert!(pca_original.scale().is_some(), "Original (exact) model scale should be Some");
-        assert_eq!(pca_original.rotation().unwrap().ncols(), expected_components, "Original (exact) model component count mismatch");
+        assert!(
+            pca_original.rotation().is_some(),
+            "Original (exact) model rotation should be Some"
+        );
+        assert!(
+            pca_original.mean().is_some(),
+            "Original (exact) model mean should be Some"
+        );
+        assert!(
+            pca_original.scale().is_some(),
+            "Original (exact) model scale should be Some"
+        );
+        assert_eq!(
+            pca_original.rotation().unwrap().ncols(),
+            expected_components,
+            "Original (exact) model component count mismatch"
+        );
 
         let temp_file = NamedTempFile::new()?;
         let file_path = temp_file.path();
@@ -738,21 +812,39 @@ mod model_persistence_tests {
         println!("Exact model loaded successfully.");
 
         // 1. Verify loaded model parameters are identical
-        assert_optional_array2_equals(pca_original.rotation(), pca_loaded.rotation(), "rotation matrix (exact fit)");
-        assert_optional_array1_equals(pca_original.mean(), pca_loaded.mean(), "mean vector (exact fit)");
-        assert_optional_array1_equals(pca_original.scale(), pca_loaded.scale(), "scale vector (exact fit)");
+        assert_optional_array2_equals(
+            pca_original.rotation(),
+            pca_loaded.rotation(),
+            "rotation matrix (exact fit)",
+        );
+        assert_optional_array1_equals(
+            pca_original.mean(),
+            pca_loaded.mean(),
+            "mean vector (exact fit)",
+        );
+        assert_optional_array1_equals(
+            pca_original.scale(),
+            pca_loaded.scale(),
+            "scale vector (exact fit)",
+        );
 
         // 2. Verify transformation results are identical
-        let data_to_transform = array![
-            [2.0, 3.0, 4.0, 5.5, 6.0],
-            [6.0, 7.0, 8.0, 9.5, 10.0]
-        ];
+        let data_to_transform = array![[2.0, 3.0, 4.0, 5.5, 6.0], [6.0, 7.0, 8.0, 9.5, 10.0]];
         let transformed_original = pca_original.transform(data_to_transform.clone())?;
         let transformed_loaded = pca_loaded.transform(data_to_transform.clone())?;
 
-        assert_eq!(transformed_original.dim(), transformed_loaded.dim(), "Transformed data dimension mismatch (exact fit)");
+        assert_eq!(
+            transformed_original.dim(),
+            transformed_loaded.dim(),
+            "Transformed data dimension mismatch (exact fit)"
+        );
         for (val_orig, val_load) in transformed_original.iter().zip(transformed_loaded.iter()) {
-            assert!((val_orig - val_load).abs() < COMPARISON_TOLERANCE, "Mismatch in transformed data after load (exact fit): {} vs {}", val_orig, val_load);
+            assert!(
+                (val_orig - val_load).abs() < COMPARISON_TOLERANCE,
+                "Mismatch in transformed data after load (exact fit): {} vs {}",
+                val_orig,
+                val_load
+            );
         }
         println!("Save/Load test for exact fit passed.");
         Ok(())
@@ -776,8 +868,15 @@ mod model_persistence_tests {
         let _ = pca_original.rfit(data.clone(), n_components_to_fit, 10, Some(123), None)?; // Using more oversamples
 
         // Pre-save assertions
-        assert!(pca_original.rotation().is_some(), "Original (randomized) model rotation should be Some");
-        assert_eq!(pca_original.rotation().unwrap().ncols(), n_components_to_fit, "Original (randomized) model component count mismatch");
+        assert!(
+            pca_original.rotation().is_some(),
+            "Original (randomized) model rotation should be Some"
+        );
+        assert_eq!(
+            pca_original.rotation().unwrap().ncols(),
+            n_components_to_fit,
+            "Original (randomized) model component count mismatch"
+        );
 
         let temp_file = NamedTempFile::new()?;
         let file_path = temp_file.path();
@@ -788,21 +887,39 @@ mod model_persistence_tests {
         println!("Randomized model loaded successfully.");
 
         // 1. Verify loaded model parameters
-        assert_optional_array2_equals(pca_original.rotation(), pca_loaded.rotation(), "rotation matrix (randomized fit)");
-        assert_optional_array1_equals(pca_original.mean(), pca_loaded.mean(), "mean vector (randomized fit)");
-        assert_optional_array1_equals(pca_original.scale(), pca_loaded.scale(), "scale vector (randomized fit)");
+        assert_optional_array2_equals(
+            pca_original.rotation(),
+            pca_loaded.rotation(),
+            "rotation matrix (randomized fit)",
+        );
+        assert_optional_array1_equals(
+            pca_original.mean(),
+            pca_loaded.mean(),
+            "mean vector (randomized fit)",
+        );
+        assert_optional_array1_equals(
+            pca_original.scale(),
+            pca_loaded.scale(),
+            "scale vector (randomized fit)",
+        );
 
         // 2. Verify transformation results
-        let data_to_transform = array![
-            [2.5, 3.5, 4.5, 5.0, 0.0],
-            [6.5, 7.5, 8.5, 9.0, 1.0]
-        ];
+        let data_to_transform = array![[2.5, 3.5, 4.5, 5.0, 0.0], [6.5, 7.5, 8.5, 9.0, 1.0]];
         let transformed_original = pca_original.transform(data_to_transform.clone())?;
         let transformed_loaded = pca_loaded.transform(data_to_transform.clone())?;
 
-        assert_eq!(transformed_original.dim(), transformed_loaded.dim(), "Transformed data dimension mismatch (randomized fit)");
+        assert_eq!(
+            transformed_original.dim(),
+            transformed_loaded.dim(),
+            "Transformed data dimension mismatch (randomized fit)"
+        );
         for (val_orig, val_load) in transformed_original.iter().zip(transformed_loaded.iter()) {
-            assert!((val_orig - val_load).abs() < COMPARISON_TOLERANCE, "Mismatch in transformed data after load (randomized fit): {} vs {}", val_orig, val_load);
+            assert!(
+                (val_orig - val_load).abs() < COMPARISON_TOLERANCE,
+                "Mismatch in transformed data after load (randomized fit): {} vs {}",
+                val_orig,
+                val_load
+            );
         }
         println!("Save/Load test for randomized fit passed.");
         Ok(())
@@ -811,7 +928,8 @@ mod model_persistence_tests {
     #[test]
     fn test_save_load_model_with_zero_components() -> Result<(), Box<dyn Error>> {
         println!("--- Test: Save/Load Model with Zero Components ---");
-        let data = array![ // Data that will likely result in 0 components with high tolerance
+        let data = array![
+            // Data that will likely result in 0 components with high tolerance
             [1.0, 1.0, 1.0],
             [1.0, 1.0, 1.0],
             [1.0, 1.0, 1.0]
@@ -819,10 +937,17 @@ mod model_persistence_tests {
 
         let mut pca_original = PCA::new();
         // Use a very high tolerance that should mean no components are kept
-        pca_original.fit(data.clone(), Some(0.999999999))?; 
+        pca_original.fit(data.clone(), Some(0.999999999))?;
 
-        assert!(pca_original.rotation().is_some(), "Original model (zero components) rotation should be Some");
-        assert_eq!(pca_original.rotation().unwrap().ncols(), 0, "Model with no significant variance should have 0 components");
+        assert!(
+            pca_original.rotation().is_some(),
+            "Original model (zero components) rotation should be Some"
+        );
+        assert_eq!(
+            pca_original.rotation().unwrap().ncols(),
+            0,
+            "Model with no significant variance should have 0 components"
+        );
 
         let temp_file = NamedTempFile::new()?;
         let file_path = temp_file.path();
@@ -832,18 +957,34 @@ mod model_persistence_tests {
         let pca_loaded = PCA::load_model(file_path)?;
         println!("Zero-component model loaded successfully.");
 
-        assert_optional_array2_equals(pca_original.rotation(), pca_loaded.rotation(), "rotation (zero components)");
-        assert_eq!(pca_loaded.rotation().unwrap().ncols(), 0, "Loaded model should have 0 components");
+        assert_optional_array2_equals(
+            pca_original.rotation(),
+            pca_loaded.rotation(),
+            "rotation (zero components)",
+        );
+        assert_eq!(
+            pca_loaded.rotation().unwrap().ncols(),
+            0,
+            "Loaded model should have 0 components"
+        );
 
         let data_to_transform = array![[1.1, 1.1, 1.1], [2.2, 2.2, 2.2]];
         let transformed_original = pca_original.transform(data_to_transform.clone())?;
         let transformed_loaded = pca_loaded.transform(data_to_transform.clone())?;
-        
-        assert_eq!(transformed_original.ncols(), 0, "Original transform output should have 0 columns");
-        assert_eq!(transformed_loaded.ncols(), 0, "Loaded transform output should have 0 columns");
+
+        assert_eq!(
+            transformed_original.ncols(),
+            0,
+            "Original transform output should have 0 columns"
+        );
+        assert_eq!(
+            transformed_loaded.ncols(),
+            0,
+            "Loaded transform output should have 0 columns"
+        );
         assert_eq!(transformed_original.nrows(), data_to_transform.nrows());
         assert_eq!(transformed_loaded.nrows(), data_to_transform.nrows());
-        
+
         println!("Save/Load test for zero-component model passed.");
         Ok(())
     }
@@ -853,12 +994,10 @@ mod model_persistence_tests {
         println!("--- Test: `with_model` Constructor and Persistence ---");
         let d_features = 4;
         let k_components = 2;
-        let rotation = Array2::from_shape_vec((d_features, k_components), vec![
-            0.5, 0.5, 
-            -0.5, 0.5, 
-            0.5, -0.5,
-            -0.5, -0.5
-        ])?; // Example orthonormal columns
+        let rotation = Array2::from_shape_vec(
+            (d_features, k_components),
+            vec![0.5, 0.5, -0.5, 0.5, 0.5, -0.5, -0.5, -0.5],
+        )?; // Example orthonormal columns
         let mean = Array1::from(vec![10.0, 20.0, 30.0, 40.0]);
         let raw_std_devs = Array1::from(vec![1.0, 0.0000000001, 2.0, 0.0]); // One near-zero, one zero
 
@@ -866,25 +1005,40 @@ mod model_persistence_tests {
 
         // Verify internal sanitization of scale
         let expected_sanitized_scale = array![1.0, 1.0, 2.0, 1.0];
-        assert_optional_array1_equals(Some(&expected_sanitized_scale), pca_original.scale(), "sanitized scale in with_model");
+        assert_optional_array1_equals(
+            Some(&expected_sanitized_scale),
+            pca_original.scale(),
+            "sanitized scale in with_model",
+        );
 
         let temp_file = NamedTempFile::new()?;
         let file_path = temp_file.path();
         pca_original.save_model(file_path)?;
         println!("Model created with `with_model` saved to: {:?}", file_path);
-        
+
         let pca_loaded = PCA::load_model(file_path)?;
         println!("Model loaded successfully.");
 
-        assert_optional_array2_equals(pca_original.rotation(), pca_loaded.rotation(), "rotation (with_model)");
+        assert_optional_array2_equals(
+            pca_original.rotation(),
+            pca_loaded.rotation(),
+            "rotation (with_model)",
+        );
         assert_optional_array1_equals(pca_original.mean(), pca_loaded.mean(), "mean (with_model)");
-        assert_optional_array1_equals(pca_original.scale(), pca_loaded.scale(), "scale (with_model, should be sanitized)");
-        assert_optional_array1_equals(Some(&expected_sanitized_scale), pca_loaded.scale(), "loaded scale should match expected sanitized");
-
+        assert_optional_array1_equals(
+            pca_original.scale(),
+            pca_loaded.scale(),
+            "scale (with_model, should be sanitized)",
+        );
+        assert_optional_array1_equals(
+            Some(&expected_sanitized_scale),
+            pca_loaded.scale(),
+            "loaded scale should match expected sanitized",
+        );
 
         let data_to_transform = array![
             [11.0, 20.0, 32.0, 40.0], // Orig: [1,0,2,0], Centered: [1,0,2,0], Scaled by [1,1,2,1]: [1,0,1,0]
-            [10.0, 21.0, 30.0, 41.0]  // Orig: [0,1,0,1], Centered: [0,1,0,1], Scaled by [1,1,2,1]: [0,1,0,1]
+            [10.0, 21.0, 30.0, 41.0] // Orig: [0,1,0,1], Centered: [0,1,0,1], Scaled by [1,1,2,1]: [0,1,0,1]
         ];
         // Expected projection for P1 ([1,0,1,0]):
         // PC1: 1*0.5 + 0*(-0.5) + 1*0.5 + 0*(-0.5) = 0.5 + 0.5 = 1.0
@@ -893,14 +1047,25 @@ mod model_persistence_tests {
         // PC1: 0*0.5 + 1*(-0.5) + 0*0.5 + 1*(-0.5) = -0.5 - 0.5 = -1.0
         // PC2: 0*0.5 + 1*0.5    + 0*(-0.5)+ 1*(-0.5) =  0.5 - 0.5 =  0.0
         let expected_transformed = array![[1.0, 0.0], [-1.0, 0.0]];
-        
+
         let transformed_loaded = pca_loaded.transform(data_to_transform)?;
-        
-        assert_eq!(transformed_loaded.dim(), (2, k_components), "Transformed data dimension mismatch (with_model)");
+
+        assert_eq!(
+            transformed_loaded.dim(),
+            (2, k_components),
+            "Transformed data dimension mismatch (with_model)"
+        );
         for r in 0..transformed_loaded.nrows() {
             for c in 0..transformed_loaded.ncols() {
-                assert!((transformed_loaded[[r,c]] - expected_transformed[[r,c]]).abs() < COMPARISON_TOLERANCE,
-                    "Mismatch at [{},{}] (with_model): {} vs {}", r,c, transformed_loaded[[r,c]], expected_transformed[[r,c]]);
+                assert!(
+                    (transformed_loaded[[r, c]] - expected_transformed[[r, c]]).abs()
+                        < COMPARISON_TOLERANCE,
+                    "Mismatch at [{},{}] (with_model): {} vs {}",
+                    r,
+                    c,
+                    transformed_loaded[[r, c]],
+                    expected_transformed[[r, c]]
+                );
             }
         }
         println!("`with_model` constructor, persistence, and transform test passed.");
@@ -917,12 +1082,18 @@ mod model_persistence_tests {
         let scale_valid_sanitized = Array1::ones(d_features);
 
         // 1. Test loading non-existent file
-        assert!(PCA::load_model("a_surely_non_existent_file.pca_model").is_err(), "Loading non-existent file should fail");
+        assert!(
+            PCA::load_model("a_surely_non_existent_file.pca_model").is_err(),
+            "Loading non-existent file should fail"
+        );
 
         // 2. Test loading a file that is not a valid bincode PCA model
         let empty_temp_file = NamedTempFile::new()?;
         // File is empty, so deserialization should fail
-        assert!(PCA::load_model(empty_temp_file.path()).is_err(), "Loading an empty file should fail deserialization");
+        assert!(
+            PCA::load_model(empty_temp_file.path()).is_err(),
+            "Loading an empty file should fail deserialization"
+        );
 
         // 3. Test loading a model with inconsistent dimensions (crafted struct, then saved)
         let rotation_bad_dim = Array2::zeros((d_features + 1, k_components)); // Mismatched feature count
@@ -934,7 +1105,10 @@ mod model_persistence_tests {
         };
         let temp_file_bad_dim = NamedTempFile::new()?;
         bad_dim_pca_struct.save_model(temp_file_bad_dim.path())?;
-        assert!(PCA::load_model(temp_file_bad_dim.path()).is_err(), "Load should fail for inconsistent dimensions in saved model");
+        assert!(
+            PCA::load_model(temp_file_bad_dim.path()).is_err(),
+            "Load should fail for inconsistent dimensions in saved model"
+        );
 
         // 4. Test loading a model with invalid scale vector (e.g., containing zero after it should have been sanitized)
         // To test load_model's check, we construct a PCA struct with a non-sanitized scale (containing zero)
@@ -948,8 +1122,11 @@ mod model_persistence_tests {
         };
         let temp_file_zero_scale = NamedTempFile::new()?;
         zero_scale_pca_struct.save_model(temp_file_zero_scale.path())?;
-        assert!(PCA::load_model(temp_file_zero_scale.path()).is_err(), "Load should fail for scale vector with zero");
-        
+        assert!(
+            PCA::load_model(temp_file_zero_scale.path()).is_err(),
+            "Load should fail for scale vector with zero"
+        );
+
         println!("`load_model` error condition tests passed.");
         Ok(())
     }
@@ -961,17 +1138,21 @@ mod model_persistence_tests {
         let k_components = 2;
         let rotation = Array2::zeros((d_features, k_components)); // Dummy rotation
         let mean = Array1::zeros(d_features); // Dummy mean
-        
+
         // Test with various problematic finite values for raw_standard_deviations
         let raw_stds_problematic_finite = array![-5.0, 0.0, 1e-10, 2.0, 0.5];
         // Expected outcome: non-positive or very small values become 1.0, others are preserved.
         let expected_sanitized_finite = array![1.0, 1.0, 1.0, 2.0, 0.5];
-        
-        let pca_model_finite = PCA::with_model(rotation.clone(), mean.clone(), raw_stds_problematic_finite.clone())?;
+
+        let pca_model_finite = PCA::with_model(
+            rotation.clone(),
+            mean.clone(),
+            raw_stds_problematic_finite.clone(),
+        )?;
         assert_optional_array1_equals(
-            Some(&expected_sanitized_finite), 
-            pca_model_finite.scale(), 
-            "scale sanitization for problematic finite values in with_model"
+            Some(&expected_sanitized_finite),
+            pca_model_finite.scale(),
+            "scale sanitization for problematic finite values in with_model",
         );
 
         // Test that an error is returned for non-finite values by the initial check in `with_model`.
@@ -982,7 +1163,7 @@ mod model_persistence_tests {
         );
 
         let raw_stds_with_inf = array![1.0, f64::INFINITY, 2.0];
-         assert!(
+        assert!(
             PCA::with_model(rotation.clone(), mean.clone(), raw_stds_with_inf).is_err(),
             "with_model should error on non-finite (infinity) raw_standard_deviations due to the explicit check"
         );
@@ -1012,13 +1193,13 @@ mod model_persistence_tests {
         let temp_file_neg_scale = NamedTempFile::new()?;
         // Save this struct which has a negative scale.
         // `save_model` itself doesn't validate the PCA internals, only that fields are Some.
-        pca_negative_scale.save_model(temp_file_neg_scale.path())?; 
+        pca_negative_scale.save_model(temp_file_neg_scale.path())?;
         // `load_model` should now reject this due to the `val <= 0.0` check.
         assert!(
             PCA::load_model(temp_file_neg_scale.path()).is_err(),
             "Load should fail for a saved model with a negative value in its scale vector."
         );
-        
+
         // Case 2: Scale with zero (this scenario is also covered by test_load_model_error_conditions).
         // Re-confirming that the `val <= 0.0` check correctly handles this.
         let scale_with_zero = Array1::from_vec(vec![1.0, 0.0, 2.0]);
@@ -1030,7 +1211,7 @@ mod model_persistence_tests {
         };
         let temp_file_zero_scale = NamedTempFile::new()?;
         pca_zero_scale.save_model(temp_file_zero_scale.path())?;
-         assert!(
+        assert!(
             PCA::load_model(temp_file_zero_scale.path()).is_err(),
             "Load should fail for a saved model with a zero value in its scale vector."
         );
@@ -1218,10 +1399,11 @@ mod pca_tests {
         let rust_transformed = if is_rpca {
             // rfit consumes the input and returns the transformed PCs.
             // Input is cloned as it was originally cloned for rfit then again for transform.
-            pca.rfit(input.clone(), n_components, oversamples, seed, None).unwrap()
+            pca.rfit(input.clone(), n_components, oversamples, seed, None)
+                .unwrap()
         } else {
             pca.fit(input.clone(), None).unwrap(); // fit does not return PCs
-            // so, transform is still needed after fit.
+                                                   // so, transform is still needed after fit.
             pca.transform(input.clone()).unwrap()
         };
 
@@ -1235,24 +1417,17 @@ mod pca_tests {
     }
 
     use super::*; // This brings PcaReferenceResults into scope for this module if it's outside
-    // use ndarray::array; // Already imported at top level of file
+                  // use ndarray::array; // Already imported at top level of file
     use ndarray_rand::rand_distr::Distribution;
-        
-    
-    
+
     #[test]
     fn test_pca_fit_consistency_linfa() -> Result<(), Box<dyn std::error::Error>> {
         const TOLERANCE: f64 = 1e-5;
-    
+
         // Use the aliased ndarray v0.15.6 for linfa-related data
         use ndarray_v15;
-    
-        fn assert_f64_slices_approx_equal(
-            s1: &[f64],
-            s2: &[f64],
-            tol: f64,
-            context_msg: &str,
-        ) {
+
+        fn assert_f64_slices_approx_equal(s1: &[f64], s2: &[f64], tol: f64, context_msg: &str) {
             assert_eq!(s1.len(), s2.len(), "Length mismatch for '{}': expected {}, got {}. s1_len: {}, s2_len: {}. s1 first 5: {:?}, s2 first 5: {:?}", context_msg, s2.len(), s1.len(), s1.len(), s2.len(), s1.iter().take(5).collect::<Vec<_>>(), s2.iter().take(5).collect::<Vec<_>>());
             for i in 0..s1.len() {
                 if !approx::abs_diff_eq!(s1[i], s2[i], epsilon = tol) {
@@ -1263,27 +1438,52 @@ mod pca_tests {
                 }
             }
         }
-    
+
         fn assert_matrix_cols_vec_approx_equal_columnwise_sign_agnostic(
             m1_cols_as_vec: &[Vec<f64>],
             m2_cols_as_vec: &[Vec<f64>],
             tol: f64,
             context_msg: &str,
         ) {
-            assert_eq!(m1_cols_as_vec.len(), m2_cols_as_vec.len(), "Column count mismatch for '{}': expected {}, got {}.", context_msg, m2_cols_as_vec.len(), m1_cols_as_vec.len());
+            assert_eq!(
+                m1_cols_as_vec.len(),
+                m2_cols_as_vec.len(),
+                "Column count mismatch for '{}': expected {}, got {}.",
+                context_msg,
+                m2_cols_as_vec.len(),
+                m1_cols_as_vec.len()
+            );
             if m1_cols_as_vec.is_empty() {
-                assert!(m2_cols_as_vec.is_empty(), "M1 is empty but M2 is not for '{}'", context_msg);
+                assert!(
+                    m2_cols_as_vec.is_empty(),
+                    "M1 is empty but M2 is not for '{}'",
+                    context_msg
+                );
                 return;
             }
-            assert!(!m2_cols_as_vec.is_empty(), "M2 is empty but M1 is not for '{}'", context_msg);
-    
+            assert!(
+                !m2_cols_as_vec.is_empty(),
+                "M2 is empty but M1 is not for '{}'",
+                context_msg
+            );
+
             for j in 0..m1_cols_as_vec.len() {
                 let col1 = &m1_cols_as_vec[j];
                 let col2 = &m2_cols_as_vec[j];
-    
-                assert_eq!(col1.len(), col2.len(), "Row count mismatch for column {} in '{}'. col1_len: {}, col2_len: {}", j, context_msg, col1.len(), col2.len());
-                if col1.is_empty() { continue; }
-    
+
+                assert_eq!(
+                    col1.len(),
+                    col2.len(),
+                    "Row count mismatch for column {} in '{}'. col1_len: {}, col2_len: {}",
+                    j,
+                    context_msg,
+                    col1.len(),
+                    col2.len()
+                );
+                if col1.is_empty() {
+                    continue;
+                }
+
                 let mut same_sign_match = true;
                 for i in 0..col1.len() {
                     if !approx::abs_diff_eq!(col1[i], col2[i], epsilon = tol) {
@@ -1291,8 +1491,10 @@ mod pca_tests {
                         break;
                     }
                 }
-                if same_sign_match { continue; }
-    
+                if same_sign_match {
+                    continue;
+                }
+
                 let mut flipped_sign_match = true;
                 for i in 0..col1.len() {
                     if !approx::abs_diff_eq!(col1[i], -col2[i], epsilon = tol) {
@@ -1315,20 +1517,16 @@ mod pca_tests {
                 }
             }
         }
-    
+
         // Data matrix (created using efficient_pca's ndarray v0.16.1 via array! macro)
         // Note: `array!` macro comes from the `ndarray` crate imported at the top of the file (v0.16.1)
-        let data_matrix_owned_v161 = array![
-            [1., 2., 3.],
-            [4., 5., 6.],
-            [7., 8., 9.],
-            [10., 11., 12.]
-        ];
-    
+        let data_matrix_owned_v161 =
+            array![[1., 2., 3.], [4., 5., 6.], [7., 8., 9.], [10., 11., 12.]];
+
         let n_samples = data_matrix_owned_v161.nrows();
         let n_features = data_matrix_owned_v161.ncols();
         let k_components = n_features.min(n_samples);
-    
+
         // --- Fit efficient_pca models (uses ndarray v0.16.1) ---
         let mut pca_fit_eff = PCA::new();
         pca_fit_eff.fit(data_matrix_owned_v161.clone(), None)?;
@@ -1336,21 +1534,29 @@ mod pca_tests {
         let rotation_fit_eff_v161 = pca_fit_eff.rotation().unwrap();
         let transformed_fit_eff_v161 = pca_fit_eff.transform(data_matrix_owned_v161.clone())?;
         let explained_variance_fit_eff_v161 = pca_fit_eff.explained_variance().unwrap();
-        let singular_values_from_fit_eff_v161 = explained_variance_fit_eff_v161.mapv(|ev| (ev * (n_samples.saturating_sub(1)) as f64).max(0.0).sqrt());
-    
+        let singular_values_from_fit_eff_v161 = explained_variance_fit_eff_v161
+            .mapv(|ev| (ev * (n_samples.saturating_sub(1)) as f64).max(0.0).sqrt());
+
         let mut pca_rfit_eff = PCA::new();
-        let transformed_rfit_eff_v161 = pca_rfit_eff.rfit(data_matrix_owned_v161.clone(), k_components, 2, Some(42), None)?;
+        let transformed_rfit_eff_v161 = pca_rfit_eff.rfit(
+            data_matrix_owned_v161.clone(),
+            k_components,
+            2,
+            Some(42),
+            None,
+        )?;
         let mean_rfit_eff_v161 = pca_rfit_eff.mean().unwrap();
         let rotation_rfit_eff_v161 = pca_rfit_eff.rotation().unwrap();
         let explained_variance_rfit_eff_v161 = pca_rfit_eff.explained_variance().unwrap();
-        let singular_values_from_rfit_eff_v161 = explained_variance_rfit_eff_v161.mapv(|ev| (ev * (n_samples.saturating_sub(1)) as f64).max(0.0).sqrt());
-    
+        let singular_values_from_rfit_eff_v161 = explained_variance_rfit_eff_v161
+            .mapv(|ev| (ev * (n_samples.saturating_sub(1)) as f64).max(0.0).sqrt());
+
         // --- Prepare data for Linfa using ndarray_v15 (ndarray v0.15.6) ---
         let mut data_for_linfa_v15 = ndarray_v15::Array2::zeros(data_matrix_owned_v161.dim());
         for ((r, c), &val) in data_matrix_owned_v161.indexed_iter() {
             data_for_linfa_v15[[r, c]] = val;
         }
-    
+
         // --- Fit LinfaPcaModel ---
         let linfa_dataset = DatasetBase::from(data_for_linfa_v15);
         let linfa_pca_model = LinfaPcaModel::params(k_components).fit(&linfa_dataset)?;
@@ -1358,62 +1564,127 @@ mod pca_tests {
         let components_linfa_v15 = linfa_pca_model.components(); // ndarray_v15::Array2
         let transformed_linfa_v15 = linfa_pca_model.predict(&linfa_dataset); // ndarray_v15::Array2
         let singular_values_linfa_v15 = linfa_pca_model.singular_values(); // ndarray_v15::Array1
-    
+
         // --- Perform Comparisons: Convert all ndarray types to Vec<f64> or Vec<Vec<f64>> ---
         let mean_fit_eff_vec: Vec<f64> = mean_fit_eff_v161.to_vec();
         let mean_rfit_eff_vec: Vec<f64> = mean_rfit_eff_v161.to_vec();
         let mean_linfa_vec: Vec<f64> = mean_linfa_v15.to_vec(); // Use .to_vec() from ndarray_v15
-    
-        assert_f64_slices_approx_equal(&mean_fit_eff_vec, &mean_linfa_vec, TOLERANCE, "Mean (fit vs linfa)");
-        assert_f64_slices_approx_equal(&mean_rfit_eff_vec, &mean_linfa_vec, TOLERANCE, "Mean (rfit vs linfa)");
-    
-        let rotation_fit_eff_cols_vec: Vec<Vec<f64>> = rotation_fit_eff_v161.columns().into_iter().map(|col| col.to_vec()).collect();
-        let rotation_rfit_eff_cols_vec: Vec<Vec<f64>> = rotation_rfit_eff_v161.columns().into_iter().map(|col| col.to_vec()).collect();
-    
+
+        assert_f64_slices_approx_equal(
+            &mean_fit_eff_vec,
+            &mean_linfa_vec,
+            TOLERANCE,
+            "Mean (fit vs linfa)",
+        );
+        assert_f64_slices_approx_equal(
+            &mean_rfit_eff_vec,
+            &mean_linfa_vec,
+            TOLERANCE,
+            "Mean (rfit vs linfa)",
+        );
+
+        let rotation_fit_eff_cols_vec: Vec<Vec<f64>> = rotation_fit_eff_v161
+            .columns()
+            .into_iter()
+            .map(|col| col.to_vec())
+            .collect();
+        let rotation_rfit_eff_cols_vec: Vec<Vec<f64>> = rotation_rfit_eff_v161
+            .columns()
+            .into_iter()
+            .map(|col| col.to_vec())
+            .collect();
+
         // Linfa's .components() method returns a matrix of shape (n_actual_components, n_features),
         // where each ROW is a principal component vector. For the rank-1 data used in this test,
         // Linfa correctly identifies 1 actual component, so components_linfa_v15 will have shape (1, 3).
-        let linfa_component_vectors: Vec<Vec<f64>> = components_linfa_v15.rows().into_iter().map(|row| row.to_vec()).collect();
-    
+        let linfa_component_vectors: Vec<Vec<f64>> = components_linfa_v15
+            .rows()
+            .into_iter()
+            .map(|row| row.to_vec())
+            .collect();
+
         // --- Comparison for 'fit' vs Linfa Rotation/Components ---
         // We will compare only up to the number of components Linfa provides, so we compare actual component vectors.
-        let num_components_to_compare_fit = std::cmp::min(rotation_fit_eff_cols_vec.len(), linfa_component_vectors.len());
-        let rotation_fit_eff_common_components: Vec<Vec<f64>> = rotation_fit_eff_cols_vec.iter().take(num_components_to_compare_fit).cloned().collect();
-        let linfa_common_components_for_fit: Vec<Vec<f64>> = linfa_component_vectors.iter().take(num_components_to_compare_fit).cloned().collect();
-    
+        let num_components_to_compare_fit = std::cmp::min(
+            rotation_fit_eff_cols_vec.len(),
+            linfa_component_vectors.len(),
+        );
+        let rotation_fit_eff_common_components: Vec<Vec<f64>> = rotation_fit_eff_cols_vec
+            .iter()
+            .take(num_components_to_compare_fit)
+            .cloned()
+            .collect();
+        let linfa_common_components_for_fit: Vec<Vec<f64>> = linfa_component_vectors
+            .iter()
+            .take(num_components_to_compare_fit)
+            .cloned()
+            .collect();
+
         assert_matrix_cols_vec_approx_equal_columnwise_sign_agnostic(
             &rotation_fit_eff_common_components,
             &linfa_common_components_for_fit,
             TOLERANCE,
-            "Rotation/Components (fit vs linfa - common components)"
+            "Rotation/Components (fit vs linfa - common components)",
         );
-    
+
         // --- Comparison for 'rfit' vs Linfa Rotation/Components ---
         // Similarly for 'rfit', compare only the common components with Linfa.
         // 'rfit' is requested with k_components (3). Linfa effectively finds 1 for this data.
-        let num_components_to_compare_rfit = std::cmp::min(rotation_rfit_eff_cols_vec.len(), linfa_component_vectors.len());
-        let rotation_rfit_eff_common_components: Vec<Vec<f64>> = rotation_rfit_eff_cols_vec.iter().take(num_components_to_compare_rfit).cloned().collect();
-        let linfa_common_components_for_rfit: Vec<Vec<f64>> = linfa_component_vectors.iter().take(num_components_to_compare_rfit).cloned().collect();
-    
+        let num_components_to_compare_rfit = std::cmp::min(
+            rotation_rfit_eff_cols_vec.len(),
+            linfa_component_vectors.len(),
+        );
+        let rotation_rfit_eff_common_components: Vec<Vec<f64>> = rotation_rfit_eff_cols_vec
+            .iter()
+            .take(num_components_to_compare_rfit)
+            .cloned()
+            .collect();
+        let linfa_common_components_for_rfit: Vec<Vec<f64>> = linfa_component_vectors
+            .iter()
+            .take(num_components_to_compare_rfit)
+            .cloned()
+            .collect();
+
         assert_matrix_cols_vec_approx_equal_columnwise_sign_agnostic(
             &rotation_rfit_eff_common_components,
             &linfa_common_components_for_rfit,
             TOLERANCE * 10.0, // Tolerance for rfit might be higher
-            "Rotation/Components (rfit vs linfa - common components)"
+            "Rotation/Components (rfit vs linfa - common components)",
         );
-            
+
         // --- Comparison for Transformed Data (fit vs Linfa) ---
         // Transformed data will have n_samples rows and k_components columns.
-        let transformed_fit_eff_cols_vec: Vec<Vec<f64>> = transformed_fit_eff_v161.columns().into_iter().map(|col| col.to_vec()).collect();
-        let transformed_linfa_cols_from_linfa_model: Vec<Vec<f64>> = transformed_linfa_v15.columns().into_iter().map(|col| col.to_vec()).collect(); // Linfa's transformed data has k_actual_linfa columns.
-    
-        let common_transformed_fit_eff: Vec<Vec<f64>> = transformed_fit_eff_cols_vec.iter().take(num_components_to_compare_fit).cloned().collect();
+        let transformed_fit_eff_cols_vec: Vec<Vec<f64>> = transformed_fit_eff_v161
+            .columns()
+            .into_iter()
+            .map(|col| col.to_vec())
+            .collect();
+        let transformed_linfa_cols_from_linfa_model: Vec<Vec<f64>> = transformed_linfa_v15
+            .columns()
+            .into_iter()
+            .map(|col| col.to_vec())
+            .collect(); // Linfa's transformed data has k_actual_linfa columns.
+
+        let common_transformed_fit_eff: Vec<Vec<f64>> = transformed_fit_eff_cols_vec
+            .iter()
+            .take(num_components_to_compare_fit)
+            .cloned()
+            .collect();
         // Make common_transformed_linfa_for_fit mutable to adjust its values
-        let mut common_transformed_linfa_for_fit: Vec<Vec<f64>> = transformed_linfa_cols_from_linfa_model.iter().take(num_components_to_compare_fit).cloned().collect();
-    
-        if !common_transformed_linfa_for_fit.is_empty() && pca_fit_eff.scale().is_some() && !pca_fit_eff.scale().unwrap().is_empty() {
+        let mut common_transformed_linfa_for_fit: Vec<Vec<f64>> =
+            transformed_linfa_cols_from_linfa_model
+                .iter()
+                .take(num_components_to_compare_fit)
+                .cloned()
+                .collect();
+
+        if !common_transformed_linfa_for_fit.is_empty()
+            && pca_fit_eff.scale().is_some()
+            && !pca_fit_eff.scale().unwrap().is_empty()
+        {
             let common_std_dev_fit = pca_fit_eff.scale().unwrap()[0]; // For this test data, stddev is same for all features.
-            if common_std_dev_fit.abs() > 1e-9 { // Avoid division by zero if std_dev is unexpectedly zero
+            if common_std_dev_fit.abs() > 1e-9 {
+                // Avoid division by zero if std_dev is unexpectedly zero
                 for pc_scores_col in common_transformed_linfa_for_fit.iter_mut() {
                     for score in pc_scores_col.iter_mut() {
                         *score /= common_std_dev_fit;
@@ -1421,24 +1692,41 @@ mod pca_tests {
                 }
             }
         }
-    
+
         assert_matrix_cols_vec_approx_equal_columnwise_sign_agnostic(
             &common_transformed_fit_eff,
             &common_transformed_linfa_for_fit, // Now adjusted
             TOLERANCE,
-            "Transformed Data (fit vs linfa - common components, Linfa scores adjusted)"
+            "Transformed Data (fit vs linfa - common components, Linfa scores adjusted)",
         );
-    
+
         // --- Comparison for Transformed Data (rfit vs Linfa) ---
         // Use num_components_to_compare_rfit determined from rotation matrices comparison.
-        let transformed_rfit_eff_cols_vec: Vec<Vec<f64>> = transformed_rfit_eff_v161.columns().into_iter().map(|col| col.to_vec()).collect();
-        let common_transformed_rfit_eff: Vec<Vec<f64>> = transformed_rfit_eff_cols_vec.iter().take(num_components_to_compare_rfit).cloned().collect();
+        let transformed_rfit_eff_cols_vec: Vec<Vec<f64>> = transformed_rfit_eff_v161
+            .columns()
+            .into_iter()
+            .map(|col| col.to_vec())
+            .collect();
+        let common_transformed_rfit_eff: Vec<Vec<f64>> = transformed_rfit_eff_cols_vec
+            .iter()
+            .take(num_components_to_compare_rfit)
+            .cloned()
+            .collect();
         // Make common_transformed_linfa_for_rfit mutable to adjust its values
-        let mut common_transformed_linfa_for_rfit: Vec<Vec<f64>> = transformed_linfa_cols_from_linfa_model.iter().take(num_components_to_compare_rfit).cloned().collect();
-    
-        if !common_transformed_linfa_for_rfit.is_empty() && pca_rfit_eff.scale().is_some() && !pca_rfit_eff.scale().unwrap().is_empty() {
+        let mut common_transformed_linfa_for_rfit: Vec<Vec<f64>> =
+            transformed_linfa_cols_from_linfa_model
+                .iter()
+                .take(num_components_to_compare_rfit)
+                .cloned()
+                .collect();
+
+        if !common_transformed_linfa_for_rfit.is_empty()
+            && pca_rfit_eff.scale().is_some()
+            && !pca_rfit_eff.scale().unwrap().is_empty()
+        {
             let common_std_dev_rfit = pca_rfit_eff.scale().unwrap()[0]; // For this test data, stddev is same for all features.
-            if common_std_dev_rfit.abs() > 1e-9 { // Avoid division by zero
+            if common_std_dev_rfit.abs() > 1e-9 {
+                // Avoid division by zero
                 for pc_scores_col in common_transformed_linfa_for_rfit.iter_mut() {
                     for score in pc_scores_col.iter_mut() {
                         *score /= common_std_dev_rfit;
@@ -1446,31 +1734,36 @@ mod pca_tests {
                 }
             }
         }
-    
+
         assert_matrix_cols_vec_approx_equal_columnwise_sign_agnostic(
             &common_transformed_rfit_eff,
             &common_transformed_linfa_for_rfit, // Now adjusted
-            TOLERANCE * 10.0, // Original higher tolerance for rfit
-            "Transformed Data (rfit vs linfa - common components, Linfa scores adjusted)"
+            TOLERANCE * 10.0,                   // Original higher tolerance for rfit
+            "Transformed Data (rfit vs linfa - common components, Linfa scores adjusted)",
         );
-    
+
         let mut sv_fit_sorted_vec: Vec<f64> = singular_values_from_fit_eff_v161.to_vec();
         sv_fit_sorted_vec.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
         let mut sv_rfit_sorted_vec: Vec<f64> = singular_values_from_rfit_eff_v161.to_vec();
         sv_rfit_sorted_vec.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
         let mut sv_linfa_sorted_vec: Vec<f64> = singular_values_linfa_v15.to_vec();
         sv_linfa_sorted_vec.sort_by(|a, b| b.partial_cmp(a).unwrap_or(std::cmp::Ordering::Equal));
-    
-        // --- Singular Value Comparisons (fit/rfit vs Linfa) ---    
-        if !sv_linfa_sorted_vec.is_empty() { // Proceed if Linfa found at least one SV
+
+        // --- Singular Value Comparisons (fit/rfit vs Linfa) ---
+        if !sv_linfa_sorted_vec.is_empty() {
+            // Proceed if Linfa found at least one SV
             let linfa_top_sv = sv_linfa_sorted_vec[0];
-    
+
             // Comparison for 'fit' vs Linfa Singular Value
             if !sv_fit_sorted_vec.is_empty() {
                 if let Some(scale_factors_fit) = pca_fit_eff.scale() {
                     if !scale_factors_fit.is_empty() {
                         let common_std_dev_fit = scale_factors_fit[0]; // For this test data, stddev is effectively same across features contributing to PC1
-                        let adjusted_linfa_sv_for_fit = if common_std_dev_fit.abs() > 1e-9 { linfa_top_sv / common_std_dev_fit } else { linfa_top_sv };
+                        let adjusted_linfa_sv_for_fit = if common_std_dev_fit.abs() > 1e-9 {
+                            linfa_top_sv / common_std_dev_fit
+                        } else {
+                            linfa_top_sv
+                        };
                         assert!(
                             approx::abs_diff_eq!(sv_fit_sorted_vec[0], adjusted_linfa_sv_for_fit, epsilon = TOLERANCE * 10.0),
                             "Top SV mismatch (fit vs Linfa adjusted): fit_sv={:.4e}, linfa_sv_adj={:.4e} (orig_linfa_sv={:.4e}, factor={:.4e})",
@@ -1485,13 +1778,17 @@ mod pca_tests {
             } else {
                 panic!("sv_fit_sorted_vec is empty, but Linfa reported {} SV(s). Inconsistent SV counts.", sv_linfa_sorted_vec.len());
             }
-    
+
             // Comparison for 'rfit' vs Linfa Singular Value
             if !sv_rfit_sorted_vec.is_empty() {
                 if let Some(scale_factors_rfit) = pca_rfit_eff.scale() {
                     if !scale_factors_rfit.is_empty() {
                         let common_std_dev_rfit = scale_factors_rfit[0]; // Similar assumption for rfit's scale
-                        let adjusted_linfa_sv_for_rfit = if common_std_dev_rfit.abs() > 1e-9 { linfa_top_sv / common_std_dev_rfit } else { linfa_top_sv };
+                        let adjusted_linfa_sv_for_rfit = if common_std_dev_rfit.abs() > 1e-9 {
+                            linfa_top_sv / common_std_dev_rfit
+                        } else {
+                            linfa_top_sv
+                        };
                         assert!(
                             approx::abs_diff_eq!(sv_rfit_sorted_vec[0], adjusted_linfa_sv_for_rfit, epsilon = TOLERANCE * 20.0),
                             "Top SV mismatch (rfit vs Linfa adjusted): rfit_sv={:.4e}, linfa_sv_adj={:.4e} (orig_linfa_sv={:.4e}, factor={:.4e})",
@@ -1506,51 +1803,70 @@ mod pca_tests {
             } else {
                 panic!("sv_rfit_sorted_vec is empty, but Linfa reported {} SV(s). Inconsistent SV counts.", sv_linfa_sorted_vec.len());
             }
-        } else { // Linfa found no SVs
+        } else {
+            // Linfa found no SVs
             // If Linfa reports 0 SVs, the PCAs should ideally also report 0 (or only near-zero SVs).
             // This checks if the PCA's SV lists are also empty or effectively all zeros.
-            let fit_is_effectively_empty = sv_fit_sorted_vec.is_empty() || sv_fit_sorted_vec.iter().all(|&x| x.abs() < TOLERANCE * 10.0);
+            let fit_is_effectively_empty = sv_fit_sorted_vec.is_empty()
+                || sv_fit_sorted_vec
+                    .iter()
+                    .all(|&x| x.abs() < TOLERANCE * 10.0);
             assert!(fit_is_effectively_empty,
                     "Expected fit SVs to be empty or near-zero if Linfa SVs are empty; fit has {} SVs: {:?}",
                     sv_fit_sorted_vec.len(), sv_fit_sorted_vec);
-    
-            let rfit_is_effectively_empty = sv_rfit_sorted_vec.is_empty() || sv_rfit_sorted_vec.iter().all(|&x| x.abs() < TOLERANCE * 20.0);
+
+            let rfit_is_effectively_empty = sv_rfit_sorted_vec.is_empty()
+                || sv_rfit_sorted_vec
+                    .iter()
+                    .all(|&x| x.abs() < TOLERANCE * 20.0);
             assert!(rfit_is_effectively_empty,
                     "Expected rfit SVs to be empty or near-zero if Linfa SVs are empty; rfit has {} SVs: {:?}",
                     sv_rfit_sorted_vec.len(), sv_rfit_sorted_vec);
         }
-    
+
         let sum_ev_fit_eff = explained_variance_fit_eff_v161.sum();
-        let ratio_fit_eff_vec: Vec<f64> = if sum_ev_fit_eff.abs() > f64::EPSILON { explained_variance_fit_eff_v161.mapv(|v| v / sum_ev_fit_eff).to_vec() } else { vec![0.0; explained_variance_fit_eff_v161.len()] };
+        let ratio_fit_eff_vec: Vec<f64> = if sum_ev_fit_eff.abs() > f64::EPSILON {
+            explained_variance_fit_eff_v161
+                .mapv(|v| v / sum_ev_fit_eff)
+                .to_vec()
+        } else {
+            vec![0.0; explained_variance_fit_eff_v161.len()]
+        };
         let sum_ev_rfit_eff = explained_variance_rfit_eff_v161.sum();
-        let ratio_rfit_eff_vec: Vec<f64> = if sum_ev_rfit_eff.abs() > f64::EPSILON { explained_variance_rfit_eff_v161.mapv(|v| v / sum_ev_rfit_eff).to_vec() } else { vec![0.0; explained_variance_rfit_eff_v161.len()] };
+        let ratio_rfit_eff_vec: Vec<f64> = if sum_ev_rfit_eff.abs() > f64::EPSILON {
+            explained_variance_rfit_eff_v161
+                .mapv(|v| v / sum_ev_rfit_eff)
+                .to_vec()
+        } else {
+            vec![0.0; explained_variance_rfit_eff_v161.len()]
+        };
         let ratio_linfa_vec: Vec<f64> = linfa_pca_model.explained_variance_ratio().to_vec(); // This uses methods of ndarray_v15::Array1
-    
+
         let len_linfa_ratio = ratio_linfa_vec.len();
-    
+
         if len_linfa_ratio > 0 {
             let mut adjusted_linfa_ratio_slice = ratio_linfa_vec.to_vec();
             if len_linfa_ratio == 1 && adjusted_linfa_ratio_slice[0].is_nan() {
                 adjusted_linfa_ratio_slice[0] = 1.0;
             }
-    
+
             if ratio_fit_eff_vec.len() >= len_linfa_ratio {
                 assert_f64_slices_approx_equal(
                     &ratio_fit_eff_vec[..len_linfa_ratio],
                     &adjusted_linfa_ratio_slice[..len_linfa_ratio],
                     TOLERANCE * 10.0,
-                    "Explained Variance Ratio (fit vs linfa - common top, Linfa NaN adj. to 1.0)"
+                    "Explained Variance Ratio (fit vs linfa - common top, Linfa NaN adj. to 1.0)",
                 );
             } else {
                 panic!("Length mismatch: Explained Variance Ratio (fit vs linfa): fit_len={}, linfa_len={}", ratio_fit_eff_vec.len(), len_linfa_ratio);
             }
-    
+
             if ratio_rfit_eff_vec.len() >= len_linfa_ratio {
                 assert_f64_slices_approx_equal(
                     &ratio_rfit_eff_vec[..len_linfa_ratio],
                     &adjusted_linfa_ratio_slice[..len_linfa_ratio], // Use the same adjusted Linfa ratio
                     TOLERANCE * 20.0,
-                    "Explained Variance Ratio (rfit vs linfa - common top, Linfa NaN adj. to 1.0)"
+                    "Explained Variance Ratio (rfit vs linfa - common top, Linfa NaN adj. to 1.0)",
                 );
             } else {
                 panic!("Length mismatch: Explained Variance Ratio (rfit vs linfa): rfit_len={}, linfa_len={}", ratio_rfit_eff_vec.len(), len_linfa_ratio);
@@ -1561,17 +1877,16 @@ mod pca_tests {
             assert!(ratio_rfit_eff_vec.is_empty() || ratio_rfit_eff_vec.iter().all(|&x| x.abs() < TOLERANCE * 20.0 || x.is_nan()),
                     "RFit EVR: expected empty or near-zero/NaN if Linfa EVR is empty; got {} elements: {:?}", ratio_rfit_eff_vec.len(), ratio_rfit_eff_vec);
         }
-    
+
         if explained_variance_fit_eff_v161.len() > 0 {
             if !approx::abs_diff_eq!(explained_variance_fit_eff_v161[0], 4.0, epsilon = TOLERANCE) {
                 panic!("Efficient PCA (fit) first explained variance for hardcoded data should be approx 4.0. Got: {}", explained_variance_fit_eff_v161[0]);
             }
         }
-    
+
         println!("Test 'test_pca_fit_consistency_linfa' (comparing with Linfa) passed with aliased ndarray_v15 and type bridging!");
         Ok(())
     }
-    
 
     #[test]
     fn test_rpca_2x2() {


### PR DESCRIPTION
Implement a zero-cost abstraction to optionally save local principal component (eigenSNP) loading vectors for each LD block.

- Added `local_pcs_output_dir: Option<String>` to `EigenSNPCoreAlgorithmConfig`.
- Made `learn_all_ld_block_local_bases` generic over a closure `F: Fn(...)` to handle local PC processing.
- Implemented dispatch logic in `compute_pca` to pass either a file-writing closure or a no-op closure to `learn_all_ld_block_local_bases` based on the configuration.
- Ensured `cargo check` and `cargo test` pass.
- Added `rust-toolchain.toml` to specify the nightly channel for SIMD features.