### PR TITLE
Use faer backend and ensure Python deps for tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ faer = { version = "0.22.6", optional = true }
 float-cmp = "0.10.0"
 log = "0.4.27"
 ndarray = { version = "0.16.1", features = ["serde", "rayon"] }
-ndarray-linalg = { version = "0.17.0", default-features = false }
+ndarray-linalg = { version = "0.17.0", default-features = false, optional = true }
 ndarray-rand = "0.15.0"
 rand = "0.8.5"
 rand_chacha = "0.3.1"
@@ -49,7 +49,6 @@ path = "src/lib.rs"
 
 [dev-dependencies]
 dirs = "6.0.0"
-reqwest = { version = "0.12.15", features = ["blocking"] }
 tar = "0.4.44"
 zstd = "0.13.3"
 criterion = { version = "0.6.0", features = ["html_reports"] }
@@ -63,13 +62,13 @@ lazy_static = "1.5.0"
 serde_json = "1.0"
 
 [features]
-default = ["backend_openblas"]
-backend_openblas = ["ndarray-linalg/openblas-static"]
-backend_openblas_system = ["ndarray-linalg/openblas-system"]
-backend_mkl = ["ndarray-linalg/intel-mkl-static"]
-backend_mkl_system = ["ndarray-linalg/intel-mkl-system"]
+default = ["backend_faer"]
+backend_openblas = ["dep:ndarray-linalg", "ndarray-linalg/openblas-static"]
+backend_openblas_system = ["dep:ndarray-linalg", "ndarray-linalg/openblas-system"]
+backend_mkl = ["dep:ndarray-linalg", "ndarray-linalg/intel-mkl-static"]
+backend_mkl_system = ["dep:ndarray-linalg", "ndarray-linalg/intel-mkl-system"]
 backend_faer = ["dep:faer"]
-faer_links_ndarray_static_openblas = ["backend_faer", "ndarray-linalg/openblas-static"]
+faer_links_ndarray_static_openblas = ["backend_faer", "backend_openblas"]
 
 # --- Utility Features ---
 jemalloc = ["dep:jemalloc-ctl"]

--- a/examples/test_backends.rs
+++ b/examples/test_backends.rs
@@ -4,12 +4,15 @@ use ndarray::Array2;
 fn main() {
     // Create a simple test matrix
     let data = Array2::from_shape_vec((3, 2), vec![1.0, 2.0, 3.0, 4.0, 5.0, 6.0]).unwrap();
-    
+
     // Create and fit PCA
     let mut pca = PCA::new();
     pca.fit(data, None).expect("PCA fit failed");
-    
+
     println!("PCA backend test works!");
     println!("Rotation matrix shape: {:?}", pca.rotation().unwrap().dim());
-    println!("Explained variance: {:?}", pca.explained_variance().unwrap());
+    println!(
+        "Explained variance: {:?}",
+        pca.explained_variance().unwrap()
+    );
 }

--- a/src/eigensnp.rs
+++ b/src/eigensnp.rs
@@ -841,8 +841,7 @@ impl EigenSNPCoreAlgorithm {
                     writeln!(writer)?;
 
                     // Zip the metadata with the rows of the loadings matrix
-                    for (snp_info, loadings_row) in
-                        block_snp_metadata.iter().zip(local_pcs.rows())
+                    for (snp_info, loadings_row) in block_snp_metadata.iter().zip(local_pcs.rows())
                     {
                         write!(
                             writer,

--- a/src/pca.rs
+++ b/src/pca.rs
@@ -3,7 +3,9 @@
 #![doc = include_str!("../README.md")]
 
 use ndarray::parallel::prelude::*;
-use ndarray::{s, Array1, Array2, ArrayViewMut1, Axis, ShapeBuilder};
+#[cfg(feature = "backend_faer")]
+use ndarray::ShapeBuilder;
+use ndarray::{s, Array1, Array2, ArrayViewMut1, Axis};
 // UPLO is no longer needed as the backend's eigh_upper handles this.
 // QR trait for .qr() and SVDInto for .svd_into() are replaced by backend calls.
 // Eigh trait for .eigh() is replaced by backend calls.

--- a/tests/eigensnp_diagnostics_tests.rs
+++ b/tests/eigensnp_diagnostics_tests.rs
@@ -163,7 +163,14 @@ fn run_diagnostic_test_with_params(
     };
 
     let algorithm = EigenSNPCoreAlgorithm::new(config.clone());
-    let snp_metadata: Vec<efficient_pca::eigensnp::PcaSnpMetadata> = (0..mock_data_accessor.num_pca_snps()).map(|i| efficient_pca::eigensnp::PcaSnpMetadata { id: std::sync::Arc::new(format!("snp_{}", i)), chr: std::sync::Arc::new("chr1".to_string()), pos: i as u64 * 1000 + 100000 }).collect();
+    let snp_metadata: Vec<efficient_pca::eigensnp::PcaSnpMetadata> = (0..mock_data_accessor
+        .num_pca_snps())
+        .map(|i| efficient_pca::eigensnp::PcaSnpMetadata {
+            id: std::sync::Arc::new(format!("snp_{}", i)),
+            chr: std::sync::Arc::new("chr1".to_string()),
+            pos: i as u64 * 1000 + 100000,
+        })
+        .collect();
     let pca_result_tuple = algorithm
         .compute_pca(&mock_data_accessor, &ld_block_specs, &snp_metadata)
         .map_err(|e| e as Box<dyn std::error::Error>)?;

--- a/tests/python_bootstrap.rs
+++ b/tests/python_bootstrap.rs
@@ -1,0 +1,51 @@
+use std::process::Command;
+use std::sync::Once;
+
+static PY_DEPS_INIT: Once = Once::new();
+
+pub fn ensure_python_packages_installed() {
+    PY_DEPS_INIT.call_once(|| {
+        let packages = [
+            ("numpy", "numpy"),
+            ("scipy", "scipy"),
+            ("scikit-learn", "sklearn"),
+        ];
+
+        let mut missing = Vec::new();
+        for (package_name, module_name) in packages.iter() {
+            let status = Command::new("python3")
+                .args(["-c", &format!("import {}", module_name)])
+                .status()
+                .expect("failed to invoke python3 to probe optional modules");
+            if !status.success() {
+                missing.push(*package_name);
+            }
+        }
+
+        if missing.is_empty() {
+            return;
+        }
+
+        println!(
+            "Installing missing Python packages required for reference PCA: {:?}",
+            missing
+        );
+
+        let mut cmd = Command::new("python3");
+        cmd.args(["-m", "pip", "install", "--user"]);
+        cmd.args(&missing);
+
+        let output = cmd
+            .output()
+            .expect("failed to invoke pip to install python dependencies");
+
+        if !output.status.success() {
+            panic!(
+                "Failed to install required python packages. Status: {:?}\nSTDOUT:\n{}\nSTDERR:\n{}",
+                output.status,
+                String::from_utf8_lossy(&output.stdout),
+                String::from_utf8_lossy(&output.stderr)
+            );
+        }
+    });
+}


### PR DESCRIPTION
## Summary
- switch the crate to prefer the faer backend and gate ndarray-linalg usage behind the OpenBLAS/MKL feature flags
- add a reusable Python dependency bootstrapper and invoke it from the PCA and EigenSNP integration tests
- rewrite the PCA tests to use Gram–Schmidt and faer eigenvalue helpers instead of ndarray-linalg utilities

## Testing
- `cargo test --no-default-features --features backend_faer` *(fails: large EigenSNP correlation/projection checks)*

------
https://chatgpt.com/codex/tasks/task_e_68d331ecae80832eb9503d1de01e6edd