### PR TITLE
Fix missing Lapack import for ndarray backends

### DIFF
--- a/src/linalg_backends.rs
+++ b/src/linalg_backends.rs
@@ -22,6 +22,14 @@ impl<F: 'static + Copy + Send + Sync> LinAlgBackendProvider<F> {
     feature = "faer_links_ndarray_static_openblas"
 ))]
 use ndarray::s;
+#[cfg(any(
+    feature = "backend_openblas",
+    feature = "backend_openblas_system",
+    feature = "backend_mkl",
+    feature = "backend_mkl_system",
+    feature = "faer_links_ndarray_static_openblas"
+))]
+use ndarray_linalg::Lapack;
 use ndarray::{Array1, Array2};
 // use num_traits::Float; // No longer needed directly by provider
 use std::error::Error;


### PR DESCRIPTION
## Summary
- add a cfg-gated `ndarray_linalg::Lapack` import so provider implementations compile when ndarray-linalg backends are enabled

## Testing
- cargo test *(fails: relies on Python-based reference checks that report low correlations without numpy/scipy/sklearn available in the container)*
- cargo check --no-default-features --features backend_openblas *(fails: OpenBLAS build script cannot download dependencies because TLS certificate verification fails in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d35de1fdc8832eb12158f82190f32e