### PR TITLE
Eliminate ndarray backend unused import warning

### DIFF
--- a/src/linalg_backends.rs
+++ b/src/linalg_backends.rs
@@ -187,7 +187,8 @@ mod ndarray_backend_impl {
         }
     }
 
-    pub use NdarrayLinAlgBackend as Backend;
+    #[cfg(not(feature = "backend_faer"))]
+    pub type Backend = NdarrayLinAlgBackend;
 }
 
 #[cfg(all(


### PR DESCRIPTION
## Summary
- replace the ndarray backend re-export with a type alias so it remains available without triggering unused-import warnings when Faer is disabled

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d396f9b9b8832e9d0430e7561bd6f5